### PR TITLE
feat: 뉴스 수집 기능 구현

### DIFF
--- a/src/main/java/com/zunza/buythedip/BuythedipApplication.java
+++ b/src/main/java/com/zunza/buythedip/BuythedipApplication.java
@@ -1,0 +1,13 @@
+package com.zunza.buythedip;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BuythedipApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(BuythedipApplication.class, args);
+	}
+
+}

--- a/src/main/java/com/zunza/buythedip/config/FinnHubConfig.kt
+++ b/src/main/java/com/zunza/buythedip/config/FinnHubConfig.kt
@@ -1,0 +1,20 @@
+package com.zunza.buythedip.config
+
+import io.finnhub.api.apis.DefaultApi
+import io.finnhub.api.infrastructure.ApiClient
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+open class FinnHubConfig {
+
+    @Value("\${finnhub.secret}")
+    lateinit var apiKey: String
+
+    @Bean
+    open fun finnHubClient(): DefaultApi {
+        ApiClient.apiKey["token"] = apiKey
+        return DefaultApi()
+    }
+}

--- a/src/main/java/com/zunza/buythedip/config/RabbitMQConfig.java
+++ b/src/main/java/com/zunza/buythedip/config/RabbitMQConfig.java
@@ -1,0 +1,49 @@
+package com.zunza.buythedip.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Declarable;
+import org.springframework.amqp.core.Declarables;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.zunza.buythedip.constant.RabbitMQConstants;
+
+@Configuration
+public class RabbitMQConfig {
+
+	private final String[] queueNames = {
+		RabbitMQConstants.NEWS_TRANSLATION_QUEUE,
+		RabbitMQConstants.NEWS_STORAGE_QUEUE
+	};
+
+	@Bean
+	public Declarables rabbitMQDeclarables() {
+		List<Declarable> declarables = new ArrayList<>();
+
+		DirectExchange exchange = new DirectExchange(RabbitMQConstants.PUBLIC_EXCHANGE, true, false);
+		declarables.add(exchange);
+
+		for (String queueName : queueNames) {
+			Queue queue = new Queue(queueName, true);
+			declarables.add(queue);
+
+			Binding binding = BindingBuilder.bind(queue).to(exchange).with(RabbitMQConstants.getRoutingKey(queueName));
+			declarables.add(binding);
+		}
+
+		return new Declarables(declarables);
+	}
+
+	@Bean
+	public MessageConverter jsonMessageConverter() {
+		return new Jackson2JsonMessageConverter();
+	}
+}

--- a/src/main/java/com/zunza/buythedip/config/SchedulerConfig.java
+++ b/src/main/java/com/zunza/buythedip/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package com.zunza.buythedip.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/src/main/java/com/zunza/buythedip/constant/RabbitMQConstants.java
+++ b/src/main/java/com/zunza/buythedip/constant/RabbitMQConstants.java
@@ -1,0 +1,20 @@
+package com.zunza.buythedip.constant;
+
+public class RabbitMQConstants {
+	public static final String PUBLIC_EXCHANGE = "public.exchange";
+
+	public static final String NEWS_TRANSLATION_QUEUE = "news.translation.queue";
+	public static final String NEWS_TRANSLATION_ROUTING_KEY = "new.translation.routing.key";
+
+	public static final String NEWS_STORAGE_QUEUE = "news.storage.queue";
+	public static final String NEWS_STORAGE_ROUTING_KEY = "new.storage.routing.key";
+
+	public static String getRoutingKey(String queue) {
+		return switch (queue) {
+			case NEWS_TRANSLATION_QUEUE -> NEWS_TRANSLATION_ROUTING_KEY;
+			case NEWS_STORAGE_QUEUE -> NEWS_STORAGE_ROUTING_KEY;
+			default -> null;
+		};
+	}
+}
+

--- a/src/main/java/com/zunza/buythedip/infrastructure/messaging/RabbitMQService.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/messaging/RabbitMQService.java
@@ -1,0 +1,17 @@
+package com.zunza.buythedip.infrastructure.messaging;
+
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RabbitMQService {
+
+	private final RabbitTemplate rabbitTemplate;
+
+	public void publishMessage(String exchange, String routingKey, Object message) {
+		rabbitTemplate.convertAndSend(exchange, routingKey, message);
+	}
+}

--- a/src/main/java/com/zunza/buythedip/news/dto/NewsDto.java
+++ b/src/main/java/com/zunza/buythedip/news/dto/NewsDto.java
@@ -1,0 +1,41 @@
+package com.zunza.buythedip.news.dto;
+
+import io.finnhub.api.models.MarketNews;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class NewsDto {
+	private String headLine;
+	private String source;
+	private String summary;
+	private String url;
+	private Long dateTime;
+
+	@Builder
+	private NewsDto(String headLine, String source, String summary, String url, Long dateTime) {
+		this.headLine = headLine;
+		this.source = source;
+		this.summary = summary;
+		this.url = url;
+		this.dateTime = dateTime;
+	}
+
+	public static NewsDto from(MarketNews marketNews) {
+		return NewsDto.builder()
+			.headLine(marketNews.getHeadline())
+			.source(marketNews.getSource())
+			.summary(marketNews.getSummary())
+			.url(marketNews.getUrl())
+			.dateTime(marketNews.getDatetime())
+			.build();
+	}
+
+	public void modifyHeadLine(String translatedHeadLine) {
+		this.headLine = translatedHeadLine;
+	}
+
+	public void modifySummary(String translatedSummary) {
+		this.summary = translatedSummary;
+	}
+}

--- a/src/main/java/com/zunza/buythedip/news/entity/MinId.java
+++ b/src/main/java/com/zunza/buythedip/news/entity/MinId.java
@@ -1,0 +1,38 @@
+package com.zunza.buythedip.news.entity;
+
+import com.zunza.buythedip.news.service.Topic;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MinId {
+
+	@Id
+	@Enumerated(EnumType.STRING)
+	private Topic topic;
+
+	private Long latestId;
+
+	public MinId(Topic topic) {
+		this.topic = topic;
+		this.latestId = 0L;
+	}
+
+	public Topic getTopic() {
+		return topic;
+	}
+
+	public Long getLatestId() {
+		return latestId;
+	}
+
+	public void updateLatestId(Long newLatestId) {
+		this.latestId = newLatestId;
+	}
+}

--- a/src/main/java/com/zunza/buythedip/news/repository/MinIdRepository.java
+++ b/src/main/java/com/zunza/buythedip/news/repository/MinIdRepository.java
@@ -1,0 +1,14 @@
+package com.zunza.buythedip.news.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.zunza.buythedip.news.entity.MinId;
+import com.zunza.buythedip.news.service.Topic;
+
+@Repository
+public interface MinIdRepository extends JpaRepository<MinId, Topic> {
+	Optional<MinId> findByTopic(Topic topic);
+}

--- a/src/main/java/com/zunza/buythedip/news/service/NewsFetchService.kt
+++ b/src/main/java/com/zunza/buythedip/news/service/NewsFetchService.kt
@@ -1,0 +1,61 @@
+package com.zunza.buythedip.news.service
+
+import com.zunza.buythedip.constant.RabbitMQConstants
+import com.zunza.buythedip.infrastructure.messaging.RabbitMQService
+import com.zunza.buythedip.news.dto.NewsDto
+import com.zunza.buythedip.news.entity.MinId
+import com.zunza.buythedip.news.repository.MinIdRepository
+import io.finnhub.api.apis.DefaultApi
+import io.finnhub.api.models.MarketNews
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+
+@Service
+class NewsFetchService(
+    private val rabbitMQService: RabbitMQService,
+    private val finnHubClient: DefaultApi,
+    private val minIdRepository: MinIdRepository
+) {
+    @Scheduled(fixedRate = 10000)
+    fun fetchNews() {
+        Topic.entries.forEach { topic ->
+            val minId = getMinId(topic)
+            val latestId = minId.latestId
+            val newsList = finnHubClient.marketNews(topic.value, latestId)
+
+            if (newsList.isNotEmpty()) {
+                val newsDtoList = newsList.stream()
+                    .map { NewsDto.from(it) }
+                    .toList()
+
+                rabbitMQService.publishMessage(
+                    RabbitMQConstants.PUBLIC_EXCHANGE,
+                    RabbitMQConstants.NEWS_TRANSLATION_ROUTING_KEY,
+                    newsDtoList
+                )
+
+                updateMinId(minId, newsList)
+            }
+        }
+    }
+
+    private fun getMinId(topic: Topic): MinId {
+        return minIdRepository.findByTopic(topic)
+            .orElseGet{ minIdRepository.save(MinId(topic)) }
+    }
+
+    private fun updateMinId(minId: MinId, newsList: List<MarketNews>) {
+        val newLatestId = newsList.stream()
+            .mapToLong { it.id!! }
+            .max()
+
+        minId.updateLatestId(newLatestId.asLong)
+        minIdRepository.save(minId)
+    }
+}
+
+enum class Topic(val value: String) {
+    GENERAL("general"),
+    CRYPTO("crypto")
+}
+


### PR DESCRIPTION
- 뉴스 수집을 위해 Finnhub API를 사용했습니다.
- kotlin SDK를 지원하는 것을 확인하고 간편한 사용을 위해 코틀린으로 코드를 작성했습니다.
- 수집한 뉴스는 메시지 큐를 통해 번역 서비스로 전달합니다.
- 뉴스 데이터 중 id를 이용하여 id 이후에 뉴스를 가져올 수 있습니다. 이를 통해 최신 뉴스만을 가져오도록 id를 DB에 업데이트 합니다.
