### PR TITLE
feat: 뉴스 번역 기능 구현

### DIFF
--- a/src/main/java/com/zunza/buythedip/config/WebClientConfig.java
+++ b/src/main/java/com/zunza/buythedip/config/WebClientConfig.java
@@ -1,0 +1,17 @@
+package com.zunza.buythedip.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+	@Bean
+	public WebClient.Builder webClient() {
+		return WebClient.builder()
+			.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
+	}
+}

--- a/src/main/java/com/zunza/buythedip/news/service/NewsTranslationService.java
+++ b/src/main/java/com/zunza/buythedip/news/service/NewsTranslationService.java
@@ -1,0 +1,50 @@
+package com.zunza.buythedip.news.service;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Service;
+
+import com.zunza.buythedip.constant.RabbitMQConstants;
+import com.zunza.buythedip.infrastructure.gemini.GeminiClient;
+import com.zunza.buythedip.infrastructure.gemini.dto.GeminiResponseDto;
+import com.zunza.buythedip.infrastructure.messaging.RabbitMQService;
+import com.zunza.buythedip.news.dto.NewsDto;
+import com.zunza.buythedip.news.util.TranslatedContentParser;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NewsTranslationService {
+
+	private final RabbitMQService rabbitMQService;
+	private final GeminiClient geminiClient;
+
+	@RabbitListener(queues = RabbitMQConstants.NEWS_TRANSLATION_QUEUE)
+	public void translateNews(List<NewsDto> newsDtoList) {
+		List<NewsDto> translatedNewsDtoList = newsDtoList.stream()
+			.map(newsDto -> {
+				String headLine = newsDto.getHeadLine();
+				String summary = newsDto.getSummary();
+				GeminiResponseDto geminiResponseDto = geminiClient.translateHeadlineAndSummary(headLine, summary).block();
+
+				String text = geminiResponseDto.getResult();
+				Map<String, String> parsed = TranslatedContentParser.parse(text);
+
+				newsDto.modifyHeadLine(parsed.get("headline"));
+				newsDto.modifySummary(parsed.get("summary"));
+				return newsDto;
+			})
+			.toList();
+
+		rabbitMQService.publishMessage(
+			RabbitMQConstants.PUBLIC_EXCHANGE,
+			RabbitMQConstants.NEWS_STORAGE_ROUTING_KEY,
+			translatedNewsDtoList
+		);
+	}
+}


### PR DESCRIPTION
- 번역을 위해 Gemini API 사용 (모델: Gemini 2.0 Flash-Lite)
- WebClient를 이용하여 API 호출
- 메지시 큐로 번역된 뉴스 데이터를 저장 서비스로 전달