### PR TITLE
fix: 스프링부트 테스트 시 스케쥴러가 실행되는 문제 해결

### DIFF
--- a/src/main/java/com/zunza/buythedip/config/SchedulerConfig.java
+++ b/src/main/java/com/zunza/buythedip/config/SchedulerConfig.java
@@ -1,9 +1,11 @@
 package com.zunza.buythedip.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Configuration
+@Profile("!test")
 @EnableScheduling
 public class SchedulerConfig {
 }


### PR DESCRIPTION
- @SpringBootTest 어노테이션을 사용하면 애플리케이션 컨텍스트를 로드하게 됩니다.
- @Configuratation 어노테이션을 사용하는 SchedulerConfig 클래스는 스캔 대상이 됩니다.
- 이로 인해 @EnableScheduling 어노테이션이 활성화 되어 스케쥴러가 실행됩니다.
- 이를 해결하기 위해 @Profile("!test) 어노테이션을 통해 테스트 프로필에서는 SchedulerConfig 빈 생성을 막아 스케쥴러 실행을 방지합니다.