### PR TITLE
fix: ResponseEntity<Void> 응답에 대한 캐스팅 문제 수정

### DIFF
--- a/src/main/java/com/zunza/buythedip/common/GlobalResponseAdvice.java
+++ b/src/main/java/com/zunza/buythedip/common/GlobalResponseAdvice.java
@@ -33,10 +33,7 @@ public class GlobalResponseAdvice implements ResponseBodyAdvice<Object> {
 		int statusCode = httpServletResponse.getStatus();
 
 		if (body == null) {
-			return ApiResponse.builder()
-				.data(null)
-				.code(statusCode)
-				.build();
+			return null;
 		}
 
 		if (body instanceof ApiResponse<?>) {


### PR DESCRIPTION
- 일관된 응답 포맷을 위해 ApiResponse 클래스를 사용하고 있음
- ResponseEntity<Void> 타입의 응답은 본문(body)을 포함하지 않아야 함 (body == null).
- 하지만 이전 로직에서는 body가 null인 경우에도 ApiResponse 객체로 변환을 시도하여 ClassCastException이 발생.
- 응답 body가 null일 경우에는 ApiResponse로 감싸지 않고 null을 직접 반환하도록 로직을 수정.