### PR TITLE
feat: 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,12 +30,19 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-amqp'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	// querydsl
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	// jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 
 	implementation 'io.finnhub:kotlin-client:2.0.20'

--- a/src/main/java/com/zunza/buythedip/common/GlobalResponseAdvice.java
+++ b/src/main/java/com/zunza/buythedip/common/GlobalResponseAdvice.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
@@ -86,5 +87,23 @@ public class GlobalResponseAdvice implements ResponseBodyAdvice<Object> {
 			.build();
 
 		return ResponseEntity.status(e.getStatusCode()).body(apiResponse);
+	}
+
+	@ExceptionHandler(AuthenticationException.class)
+	public ResponseEntity<ApiResponse<Object>> authenticationExceptionHandler(
+		AuthenticationException e
+	) {
+		String message = "아이디 또는 비밀번호를 확인해 주세요.";
+		ErrorResponse errorResponse = ErrorResponse.builder()
+			.message(message)
+			.build();
+
+		int statusCode = HttpServletResponse.SC_UNAUTHORIZED;
+		ApiResponse<Object> apiResponse = ApiResponse.builder()
+			.data(errorResponse)
+			.code(statusCode)
+			.build();
+
+		return ResponseEntity.status(statusCode).body(apiResponse);
 	}
 }

--- a/src/main/java/com/zunza/buythedip/config/RedisConfig.java
+++ b/src/main/java/com/zunza/buythedip/config/RedisConfig.java
@@ -1,0 +1,39 @@
+package com.zunza.buythedip.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+	@Value("${spring.data.redis.host}")
+	private String host;
+
+	@Value("${spring.data.redis.port}")
+	private int port;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(host, port);
+	}
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate() {
+		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+
+		redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+		redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+		return redisTemplate;
+	}
+}

--- a/src/main/java/com/zunza/buythedip/config/SecurityConfig.java
+++ b/src/main/java/com/zunza/buythedip/config/SecurityConfig.java
@@ -1,0 +1,61 @@
+package com.zunza.buythedip.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.zunza.buythedip.security.JwtAuthenticationFilter;
+import com.zunza.buythedip.security.JwtTokenProvider;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http
+			.csrf(AbstractHttpConfigurer::disable)
+			.httpBasic(AbstractHttpConfigurer::disable)
+			.formLogin(AbstractHttpConfigurer::disable)
+			.logout(AbstractHttpConfigurer::disable)
+
+			.sessionManagement(session -> session
+				.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+			)
+
+			.authorizeHttpRequests(authorize -> authorize
+				.requestMatchers("/api/auth/**").permitAll()
+				.anyRequest().authenticated()
+			)
+
+			.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+				UsernamePasswordAuthenticationFilter.class
+			);
+
+		return http.build();
+	}
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+	@Bean
+	public AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration) throws Exception {
+		return authenticationConfiguration.getAuthenticationManager();
+	}
+}

--- a/src/main/java/com/zunza/buythedip/security/CustomUserDetails.java
+++ b/src/main/java/com/zunza/buythedip/security/CustomUserDetails.java
@@ -1,0 +1,61 @@
+package com.zunza.buythedip.security;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.zunza.buythedip.user.entity.User;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+	private final User user;
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+	}
+
+	@Override
+	public String getPassword() {
+		return user.getPassword();
+	}
+
+	@Override
+	public String getUsername() {
+		return user.getAccountId();
+	}
+
+	public Long getUserId() {
+		return user.getId();
+	}
+
+	public String getNickname() {
+		return user.getNickname();
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+}

--- a/src/main/java/com/zunza/buythedip/security/CustomUserDetailsService.java
+++ b/src/main/java/com/zunza/buythedip/security/CustomUserDetailsService.java
@@ -1,0 +1,27 @@
+package com.zunza.buythedip.security;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.zunza.buythedip.user.entity.User;
+import com.zunza.buythedip.user.exception.UserNotFoundException;
+import com.zunza.buythedip.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+	private final UserRepository userRepository;
+
+	@Override
+	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+		User user = userRepository.findByAccountId(username)
+			.orElseThrow(() -> new UserNotFoundException(username));
+
+		return new CustomUserDetails(user);
+	}
+}

--- a/src/main/java/com/zunza/buythedip/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zunza/buythedip/security/JwtAuthenticationFilter.java
@@ -1,0 +1,47 @@
+package com.zunza.buythedip.security;
+
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	public static final String AUTHORIZATION_HEADER = "Authorization";
+	public static final String TOKEN_PREFIX = "Bearer ";
+
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		String jwt = resolveToken(request);
+
+		if (StringUtils.hasText(jwt) && jwtTokenProvider.validateToken(jwt)) {
+			Authentication authentication = jwtTokenProvider.getAuthentication(jwt);
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+	private String resolveToken(HttpServletRequest request) {
+		String token = request.getHeader(AUTHORIZATION_HEADER);
+
+		if (StringUtils.hasText(token) && token.startsWith(TOKEN_PREFIX)) {
+			return token.substring(7);
+		}
+
+		return null;
+	}
+}

--- a/src/main/java/com/zunza/buythedip/security/JwtTokenProvider.java
+++ b/src/main/java/com/zunza/buythedip/security/JwtTokenProvider.java
@@ -1,0 +1,112 @@
+package com.zunza.buythedip.security;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+	private static final long ACCESS_TOKEN_EXPIRE_TIME = 30 * 60 * 1000L; // 30분
+	private static final long REFRESH_TOKEN_EXPIRE_TIME = 7 * 24 * 60 * 60 * 1000L; // 7일
+
+	private final Key key;
+
+	public JwtTokenProvider(@Value("${jwt.secret}") String secretKey) {
+		log.info(secretKey);
+		byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+		this.key = Keys.hmacShaKeyFor(keyBytes);
+	}
+
+	public String generateAccessToken(Authentication authentication) {
+		CustomUserDetails principal = (CustomUserDetails)authentication.getPrincipal();
+
+		String authorities = principal.getAuthorities().stream()
+			.map(GrantedAuthority::getAuthority)
+			.collect(Collectors.joining(","));
+
+		long now = (new Date()).getTime();
+		Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+
+		return Jwts.builder()
+			.setSubject(principal.getUsername())
+			.claim("userId", principal.getUserId())
+			.claim("auth", authorities)
+			.setExpiration(accessTokenExpiresIn)
+			.signWith(key, SignatureAlgorithm.HS512)
+			.compact();
+	}
+
+	public String generateRefreshToken(Authentication authentication) {
+		CustomUserDetails principal = (CustomUserDetails)authentication.getPrincipal();
+
+		long now = (new Date()).getTime();
+		Date accessTokenExpiresIn = new Date(now + REFRESH_TOKEN_EXPIRE_TIME);
+
+		return Jwts.builder()
+			.setSubject(principal.getUsername())
+			.setExpiration(accessTokenExpiresIn)
+			.signWith(key, SignatureAlgorithm.HS512)
+			.compact();
+	}
+
+	public Authentication getAuthentication(String accessToken) {
+		Claims claims = parseClaims(accessToken);
+		Long userId = claims.get("userId", Long.class);
+
+		Collection<? extends GrantedAuthority> authorities =
+			Arrays.stream(claims.get("auth").toString().split(","))
+				.map(SimpleGrantedAuthority::new)
+				.toList();
+
+		return new UsernamePasswordAuthenticationToken(
+			userId,
+			null,
+			authorities
+		);
+	}
+
+	public boolean validateToken(String token) {
+		try {
+			Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+			return true;
+		} catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+			log.info("잘못된 JWT 서명입니다.");
+		} catch (ExpiredJwtException e) {
+			log.info("만료된 JWT 토큰입니다.");
+		} catch (UnsupportedJwtException e) {
+			log.info("지원되지 않는 JWT 토큰입니다.");
+		} catch (IllegalArgumentException e) {
+			log.info("JWT 토큰이 잘못되었습니다.");
+		}
+		return false;
+	}
+
+	private Claims parseClaims(String accessToken) {
+		try {
+			return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
+		} catch (ExpiredJwtException e) {
+			return e.getClaims();
+		}
+	}
+}

--- a/src/main/java/com/zunza/buythedip/security/RefreshTokenService.java
+++ b/src/main/java/com/zunza/buythedip/security/RefreshTokenService.java
@@ -1,0 +1,43 @@
+package com.zunza.buythedip.security;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+	private static final String REFRESH_TOKEN_PREFIX = "RT:";
+	private static final long REFRESH_TOKEN_EXPIRE_TIME = 7 * 24 * 60 * 60 * 1000L;
+
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	public void saveRefreshToken(Long userId, String refreshToken) {
+		String refreshTokenKey = getRefreshTokenKey(userId);
+		redisTemplate.opsForValue().set(refreshTokenKey, refreshToken, REFRESH_TOKEN_EXPIRE_TIME, TimeUnit.MILLISECONDS);
+	}
+
+	public String getRefreshToken(Long userId) {
+		String refreshTokenKey = getRefreshTokenKey(userId);
+		Object refreshToken = redisTemplate.opsForValue().get(refreshTokenKey);
+		return refreshToken != null ? refreshToken.toString() : null;
+	}
+
+	public void deleteRefreshToken(Long userId) {
+		String refreshTokenKey = getRefreshTokenKey(userId);
+		redisTemplate.delete(refreshTokenKey);
+	}
+
+	public boolean validateRefreshToken(Long userId, String refreshToken) {
+		String storedRefreshToken = getRefreshToken(userId);
+		return refreshToken.equals(storedRefreshToken);
+	}
+
+	private String getRefreshTokenKey(Long userId) {
+		return REFRESH_TOKEN_PREFIX + userId;
+	}
+}

--- a/src/main/java/com/zunza/buythedip/user/controller/AuthController.java
+++ b/src/main/java/com/zunza/buythedip/user/controller/AuthController.java
@@ -1,5 +1,7 @@
 package com.zunza.buythedip.user.controller;
 
+import java.util.Map;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -8,10 +10,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.zunza.buythedip.user.dto.LoginRequestDto;
+import com.zunza.buythedip.user.dto.LoginSuccessResponseDto;
 import com.zunza.buythedip.user.dto.SignupRequestDto;
 import com.zunza.buythedip.user.entity.DuplicateCheckType;
 import com.zunza.buythedip.user.service.AuthService;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -43,5 +49,22 @@ public class AuthController {
 	) {
 		authService.validateDuplicateField(DuplicateCheckType.NICKNAME, nickname);
 		return ResponseEntity.status(HttpStatus.OK).build();
+	}
+
+	@PostMapping("/api/auth/login")
+	public ResponseEntity<LoginSuccessResponseDto> login(
+		@RequestBody LoginRequestDto loginRequestDto,
+		HttpServletResponse response
+	) {
+		Map<String, String> result = authService.login(loginRequestDto);
+
+		Cookie refreshTokenCookie = new Cookie("refreshToken", result.get("refreshToken"));
+		refreshTokenCookie.setHttpOnly(true);
+		refreshTokenCookie.setPath("/");
+		refreshTokenCookie.setMaxAge((int) (7 * 24 * 60 * 60));
+
+		response.addCookie(refreshTokenCookie);
+
+		return ResponseEntity.ok(LoginSuccessResponseDto.of(result.get("nickname"), result.get("accessToken")));
 	}
 }

--- a/src/main/java/com/zunza/buythedip/user/dto/LoginRequestDto.java
+++ b/src/main/java/com/zunza/buythedip/user/dto/LoginRequestDto.java
@@ -1,0 +1,9 @@
+package com.zunza.buythedip.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class LoginRequestDto {
+	private String accountId;
+	private String password;
+}

--- a/src/main/java/com/zunza/buythedip/user/dto/LoginSuccessResponseDto.java
+++ b/src/main/java/com/zunza/buythedip/user/dto/LoginSuccessResponseDto.java
@@ -1,0 +1,23 @@
+package com.zunza.buythedip.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class LoginSuccessResponseDto {
+	private String nickname;
+	private String accessToken;
+
+	@Builder
+	private LoginSuccessResponseDto(String nickname, String accessToken) {
+		this.nickname = nickname;
+		this.accessToken = accessToken;
+	}
+
+	public static LoginSuccessResponseDto of(String nickname, String accessToken) {
+		return LoginSuccessResponseDto.builder()
+			.nickname(nickname)
+			.accessToken(accessToken)
+			.build();
+	}
+}

--- a/src/main/java/com/zunza/buythedip/user/entity/User.java
+++ b/src/main/java/com/zunza/buythedip/user/entity/User.java
@@ -37,10 +37,10 @@ public class User {
 		this.nickname = nickname;
 	}
 
-	public static User from(SignupRequestDto signupRequestDto) {
+	public static User of(SignupRequestDto signupRequestDto, String encodedPassword) {
 		return User.builder()
 			.accountId(signupRequestDto.getAccountId())
-			.password(signupRequestDto.getPassword())
+			.password(encodedPassword)
 			.nickname(signupRequestDto.getNickname())
 			.build();
 	}

--- a/src/main/java/com/zunza/buythedip/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/zunza/buythedip/user/exception/UserNotFoundException.java
@@ -1,0 +1,19 @@
+package com.zunza.buythedip.user.exception;
+
+import com.zunza.buythedip.common.CustomException;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+public class UserNotFoundException extends CustomException {
+
+    private static final String MESSAGE = "존재하지 않는 사용자 입니다. ACCOUNT ID: ";
+
+    public UserNotFoundException(String accountId) {
+        super(MESSAGE + accountId);
+    }
+
+    @Override
+    public int getStatusCode() {
+      return HttpServletResponse.SC_NOT_FOUND;
+    }
+}

--- a/src/main/java/com/zunza/buythedip/user/repository/UserRepository.java
+++ b/src/main/java/com/zunza/buythedip/user/repository/UserRepository.java
@@ -1,5 +1,7 @@
 package com.zunza.buythedip.user.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +11,5 @@ import com.zunza.buythedip.user.entity.User;
 public interface UserRepository extends JpaRepository<User, Long> {
 	boolean existsByAccountId(String accountId);
 	boolean existsByNickname(String nickname);
+	Optional<User> findByAccountId(String accountId);
 }

--- a/src/main/java/com/zunza/buythedip/user/service/AuthService.java
+++ b/src/main/java/com/zunza/buythedip/user/service/AuthService.java
@@ -1,7 +1,17 @@
 package com.zunza.buythedip.user.service;
 
+import java.util.Map;
+
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import com.zunza.buythedip.security.CustomUserDetails;
+import com.zunza.buythedip.security.JwtTokenProvider;
+import com.zunza.buythedip.security.RefreshTokenService;
+import com.zunza.buythedip.user.dto.LoginRequestDto;
 import com.zunza.buythedip.user.dto.SignupRequestDto;
 import com.zunza.buythedip.user.entity.DuplicateCheckType;
 import com.zunza.buythedip.user.entity.User;
@@ -16,6 +26,10 @@ import lombok.RequiredArgsConstructor;
 public class AuthService {
 
 	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+	private final JwtTokenProvider jwtTokenProvider;
+	private final RefreshTokenService refreshTokenService;
+	private final AuthenticationManager authenticationManager;
 
 	public void signup(SignupRequestDto signupRequestDto) {
 		if (userRepository.existsByAccountId(signupRequestDto.getAccountId())) {
@@ -26,7 +40,8 @@ public class AuthService {
 			throw new DuplicateNicknameException();
 		}
 
-		userRepository.save(User.from(signupRequestDto));
+		String encodedPassword = passwordEncoder.encode(signupRequestDto.getPassword());
+		userRepository.save(User.of(signupRequestDto,encodedPassword));
 	}
 
 	public void validateDuplicateField(DuplicateCheckType type, String value) {
@@ -45,5 +60,23 @@ public class AuthService {
 
 			default -> throw new IllegalArgumentException("지원하지 않는 필드 타입입니다.");
 		}
+	}
+
+	public Map<String, String> login(LoginRequestDto loginRequestDto) {
+		UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+			loginRequestDto.getAccountId(), loginRequestDto.getPassword());
+
+		Authentication authenticate = authenticationManager.authenticate(authenticationToken);
+		String accessToken = jwtTokenProvider.generateAccessToken(authenticate);
+		String refreshToken = jwtTokenProvider.generateRefreshToken(authenticate);
+
+		CustomUserDetails principal = (CustomUserDetails)authenticate.getPrincipal();
+		refreshTokenService.saveRefreshToken(principal.getUserId(), refreshToken);
+
+		return Map.of(
+			"nickname", principal.getNickname(),
+			"accessToken", accessToken,
+			"refreshToken", refreshToken
+		);
 	}
 }


### PR DESCRIPTION
- 로그인 성공 시 JWT 기반 Access Token 및 Refresh Token 발급
  - 로그인 성공 응답으로 Access Token과 Refresh Token을 발급하도록 구현
  - Access Token 만료 시간 30분
  - Refresh Token 만료 시간 7일

- Refresh Token 관리
  - 보안 강화를 위해 Refresh Token은 Redis에 저장하고, 동시에 HttpOnly 속성의 쿠키로 클라이언트에 전달
  - HttpOnly 쿠키 사용으로 XSS 공격으로부터 토큰을 보호
  - Redis에는 [RT:ID]:refreshToken 형태의 키로 저장

- 회원가입 시 비밀번호 해싱 적용
  - 사용자 비밀번호를 안전하게 저장하기 위해 bcrypt 알고리즘을 사용하여 해싱 처리 후 DB에 저장

- 로그인 실패 예외 처리
  - 아이디 불일치, 비밀번호 불일치 로그인 실패 케이스에 대한 예외 처리 로직을 추가
  - 실패 시 HTTP 상태 코드: 401 Unauthorized와 에러 메시지: 아이디 또는 비밀번호를 확인해 주세요. 응답