### PR TITLE
feat: 토큰 검증 및 사용자 인증에서 발생하는 예외 처리 추가

### DIFF
--- a/src/main/java/com/zunza/buythedip/config/SecurityConfig.java
+++ b/src/main/java/com/zunza/buythedip/config/SecurityConfig.java
@@ -13,7 +13,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zunza.buythedip.security.JwtAuthenticationEntryPoint;
 import com.zunza.buythedip.security.JwtAuthenticationFilter;
+import com.zunza.buythedip.security.JwtExceptionFilter;
 import com.zunza.buythedip.security.JwtTokenProvider;
 
 import lombok.RequiredArgsConstructor;
@@ -24,6 +27,7 @@ import lombok.RequiredArgsConstructor;
 public class SecurityConfig {
 
 	private final JwtTokenProvider jwtTokenProvider;
+	private final ObjectMapper objectMapper;
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -42,8 +46,15 @@ public class SecurityConfig {
 				.anyRequest().authenticated()
 			)
 
+			.addFilterBefore(new JwtExceptionFilter(objectMapper),
+				UsernamePasswordAuthenticationFilter.class
+			)
 			.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
 				UsernamePasswordAuthenticationFilter.class
+			)
+
+			.exceptionHandling(e ->
+				e.authenticationEntryPoint(new JwtAuthenticationEntryPoint(objectMapper))
 			);
 
 		return http.build();

--- a/src/main/java/com/zunza/buythedip/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/zunza/buythedip/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,43 @@
+package com.zunza.buythedip.security;
+
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zunza.buythedip.common.ApiResponse;
+import com.zunza.buythedip.common.ErrorResponse;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException authException) throws IOException, ServletException {
+
+		ErrorResponse errorResponse = ErrorResponse.builder()
+			.message("로그인이 필요한 서비스 입니다.")
+			.build();
+
+		ApiResponse<Object> apiResponse = ApiResponse.builder()
+			.data(errorResponse)
+			.code(HttpServletResponse.SC_UNAUTHORIZED)
+			.build();
+
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		response.setContentType("application/json");
+		response.setCharacterEncoding("UTF-8");
+
+		objectMapper.writeValue(response.getWriter(), apiResponse);
+	}
+}

--- a/src/main/java/com/zunza/buythedip/security/JwtExceptionFilter.java
+++ b/src/main/java/com/zunza/buythedip/security/JwtExceptionFilter.java
@@ -1,0 +1,48 @@
+package com.zunza.buythedip.security;
+
+import java.io.IOException;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zunza.buythedip.common.ApiResponse;
+import com.zunza.buythedip.common.ErrorResponse;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+	private final ObjectMapper objectMapper;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		try{
+			filterChain.doFilter(request, response);
+		} catch (ExpiredJwtException e) {
+			ErrorResponse errorResponse = ErrorResponse.builder()
+				.message("만료된 JWT 토큰 입니다.")
+				.build();
+
+			ApiResponse<Object> apiResponse = ApiResponse.builder()
+				.data(errorResponse)
+				.code(HttpServletResponse.SC_UNAUTHORIZED)
+				.build();
+
+			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+			response.setContentType("application/json");
+			response.setCharacterEncoding("UTF-8");
+
+			objectMapper.writeValue(response.getWriter(), apiResponse);
+		}
+	}
+}

--- a/src/main/java/com/zunza/buythedip/security/JwtTokenProvider.java
+++ b/src/main/java/com/zunza/buythedip/security/JwtTokenProvider.java
@@ -94,6 +94,7 @@ public class JwtTokenProvider {
 			log.info("잘못된 JWT 서명입니다.");
 		} catch (ExpiredJwtException e) {
 			log.info("만료된 JWT 토큰입니다.");
+			throw e;
 		} catch (UnsupportedJwtException e) {
 			log.info("지원되지 않는 JWT 토큰입니다.");
 		} catch (IllegalArgumentException e) {


### PR DESCRIPTION
- JWTExceptionFilter 구현
  - JwtAuthenticationFilter에서 토큰 검증 중에 발생할 수 있는 JWT 관련 예외(토큰 만료)를 전담 처리하는 JwtExceptionFilter를 구현
  - 해당 필터는 OncePerRequestFilter를 상속받아 SecurityFilterChain에서 UsernamePasswordAuthenticationFiler 앞단에 위치하도록 설정
  - 401 Unauthorized 응답을 반환

- AuthenticationEntryPoint 구현
  - 인증되지 않은 사용자의 접근에 대해 공통적으로 처리할 수 있도록 AuthenticationEntryPoint를 구현
  - SecurityContextHolder에 인증 정보가 없는 경우, 해당 EntryPoint에서 401 Unauthorized 응답을 반환
