### PR TITLE
feat: 채팅 시스템 구현

### DIFF
--- a/src/main/java/com/zunza/buythedip/chat/controller/ChatController.java
+++ b/src/main/java/com/zunza/buythedip/chat/controller/ChatController.java
@@ -1,0 +1,25 @@
+package com.zunza.buythedip.chat.controller;
+
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.zunza.buythedip.chat.dto.ChatMessageDto;
+import com.zunza.buythedip.chat.service.ChatService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class ChatController {
+
+	private final ChatService chatService;
+
+	@MessageMapping("/chat/room/public")
+	public void sendMessage(
+		ChatMessageDto chatMessageDto
+	) {
+		chatService.sendMessage(chatMessageDto);
+	}
+}

--- a/src/main/java/com/zunza/buythedip/chat/dto/ChatMessageDto.java
+++ b/src/main/java/com/zunza/buythedip/chat/dto/ChatMessageDto.java
@@ -1,0 +1,28 @@
+package com.zunza.buythedip.chat.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChatMessageDto {
+	private String sender;
+	private String content;
+	private Long timestamp;
+
+	@Builder
+	private ChatMessageDto(String sender, String content, Long timestamp) {
+		this.sender = sender;
+		this.content = content;
+		this.timestamp = timestamp;
+	}
+
+	public static ChatMessageDto of(String sender, String content, Long timestamp) {
+		return ChatMessageDto.builder()
+			.sender(sender)
+			.content(content)
+			.timestamp(timestamp)
+			.build();
+	}
+}

--- a/src/main/java/com/zunza/buythedip/chat/service/ChatService.java
+++ b/src/main/java/com/zunza/buythedip/chat/service/ChatService.java
@@ -1,0 +1,19 @@
+package com.zunza.buythedip.chat.service;
+
+import org.springframework.stereotype.Service;
+
+import com.zunza.buythedip.chat.dto.ChatMessageDto;
+import com.zunza.buythedip.infrastructure.redis.RedisMessagePublisher;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+	private final RedisMessagePublisher redisMessagePublisher;
+
+	public void sendMessage(ChatMessageDto chatMessageDto) {
+		redisMessagePublisher.publishMessage(chatMessageDto);
+	}
+}

--- a/src/main/java/com/zunza/buythedip/config/RedisListenerConfig.java
+++ b/src/main/java/com/zunza/buythedip/config/RedisListenerConfig.java
@@ -1,0 +1,38 @@
+package com.zunza.buythedip.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+
+import com.zunza.buythedip.infrastructure.redis.RedisMessageSubscriber;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisListenerConfig {
+
+	private final RedisConnectionFactory redisConnectionFactory;
+	private final RedisMessageSubscriber subscriber;
+
+	@Bean
+	public ChannelTopic chatMessageTopic() {
+		return new ChannelTopic("chat:message");
+	}
+
+	@Bean
+	public MessageListenerAdapter listenerAdapter() {
+		return new MessageListenerAdapter(subscriber, "sendMessage");
+	}
+
+	@Bean
+	public RedisMessageListenerContainer container() {
+		RedisMessageListenerContainer listenerContainer = new RedisMessageListenerContainer();
+		listenerContainer.setConnectionFactory(redisConnectionFactory);
+		listenerContainer.addMessageListener(listenerAdapter(), chatMessageTopic());
+		return listenerContainer;
+	}
+}

--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/RedisMessagePublisher.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/RedisMessagePublisher.java
@@ -1,0 +1,21 @@
+package com.zunza.buythedip.infrastructure.redis;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Service;
+
+import com.zunza.buythedip.chat.dto.ChatMessageDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RedisMessagePublisher {
+
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final ChannelTopic channelTopic;
+
+	public void publishMessage(ChatMessageDto chatMessageDto) {
+		redisTemplate.convertAndSend(channelTopic.getTopic(), chatMessageDto);
+	}
+}

--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/RedisMessageSubscriber.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/RedisMessageSubscriber.java
@@ -1,0 +1,30 @@
+package com.zunza.buythedip.infrastructure.redis;
+
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zunza.buythedip.chat.dto.ChatMessageDto;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisMessageSubscriber {
+
+	private final ObjectMapper objectMapper;
+	private final SimpMessageSendingOperations messagingTemplate;
+	private static final String DESTINATION = "/topic/chat/room/public";
+
+	public void sendMessage(String publishMessage) {
+		try {
+			ChatMessageDto chatMessageDto = objectMapper.readValue(publishMessage, ChatMessageDto.class);
+			messagingTemplate.convertAndSend(DESTINATION, chatMessageDto);
+
+		} catch (Exception e) {
+			log.error("Error processing message from Redis Pub/Sub: {}", e.getMessage(), e);
+		}
+	}
+}


### PR DESCRIPTION
**메시지 발행 요청**
- 클라이언트가 /app/chat/room/public을 통해 메시지(ChatMessageDto) 전송
- ChatController의 sendMessage() 호출
- ChatService의 sendMessage() 호출
- RedisMessageListener의 publishMessage() 메서드가 메시지를 Redis의 chat:message 토픽으로 발행

**메시지 수신**
- RedisMessageListenerContainer가 chat:message 토픽을 구독
- 메시지가 발행되면 RedisMessageSubscriber의 sendMessage() 호출
- SimpMessageSendingOperations 를 사용하여 /topic/chat/room/public 으로 메시지를 브로드캐스팅
- 해당 토피을 구독 중인 클라이언트에게 메시지 전달