### PR TITLE
fix: socketJS 연결을 위한 경로 허용

### DIFF
--- a/src/main/java/com/zunza/buythedip/config/SecurityConfig.java
+++ b/src/main/java/com/zunza/buythedip/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
 			.authorizeHttpRequests(authorize -> authorize
 				.requestMatchers("/api/auth/**").permitAll()
 				.requestMatchers("/api/news/**").permitAll()
+				.requestMatchers("/ws-chat/**").permitAll()
 				.anyRequest().authenticated()
 			)
 


### PR DESCRIPTION
- SockJS 클라이언트가 WebSocket 연결 수립 전 보내는
GET /ws-chat/info 요청이 Spring Security에 의해 차단되는 문제 해결

- Spring Security 설정에서 /ws-chat/** 경로에 대한 접근을 permitAll()로 허용하여
SockJS 핸드셰이크가 정상적으로 진행되도록 수정.