### PR TITLE
feat: 웹소켓 인터셉터 인증 추가

### DIFF
--- a/src/main/java/com/zunza/buythedip/config/StompHandler.java
+++ b/src/main/java/com/zunza/buythedip/config/StompHandler.java
@@ -1,0 +1,69 @@
+package com.zunza.buythedip.config;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import com.zunza.buythedip.security.JwtTokenProvider;
+import com.zunza.buythedip.security.exception.StompAuthenticationException;
+import com.zunza.buythedip.security.exception.StompAuthorizationHeaderException;
+import com.zunza.buythedip.security.exception.StompInvalidTokenException;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class StompHandler implements ChannelInterceptor {
+
+	private final JwtTokenProvider jwtTokenProvider;
+	private static final String BEARER_PREFIX = "Bearer ";
+
+	@Override
+	public Message<?> preSend(Message<?> message, MessageChannel channel) {
+		StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+		if (accessor == null) {
+			return message;
+		}
+
+		StompCommand command = accessor.getCommand();
+
+		if (StompCommand.CONNECT.equals(command)) {
+			return handleConnect(accessor, message);
+		}
+
+		if (StompCommand.SEND.equals(command) || StompCommand.SUBSCRIBE.equals(command)) {
+			if (accessor.getUser() == null) {
+				throw new StompAuthenticationException();
+			}
+		}
+
+		return message;
+	}
+
+	private Message<?> handleConnect(StompHeaderAccessor accessor, Message<?> message) {
+		String authorization = accessor.getFirstNativeHeader("Authorization");
+
+		if (!StringUtils.hasText(authorization)) {
+			throw new StompAuthorizationHeaderException();
+		}
+
+		if (!authorization.startsWith(BEARER_PREFIX)) {
+			throw new StompInvalidTokenException();
+		}
+
+		String jwt = authorization.substring(BEARER_PREFIX.length());
+		jwtTokenProvider.validateToken(jwt);
+
+		Authentication authentication = jwtTokenProvider.getAuthentication(jwt);
+		accessor.setUser(authentication);
+
+		return message;
+	}
+}

--- a/src/main/java/com/zunza/buythedip/config/WebSocketConfig.java
+++ b/src/main/java/com/zunza/buythedip/config/WebSocketConfig.java
@@ -1,14 +1,20 @@
 package com.zunza.buythedip.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+import lombok.RequiredArgsConstructor;
+
 @Configuration
+@RequiredArgsConstructor
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+	private final StompHandler stompHandler;
 
 	@Override
 	public void registerStompEndpoints(StompEndpointRegistry registry) {
@@ -21,5 +27,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 	public void configureMessageBroker(MessageBrokerRegistry registry) {
 		registry.enableSimpleBroker("/topic");
 		registry.setApplicationDestinationPrefixes("/app");
+	}
+
+	@Override
+	public void configureClientInboundChannel(ChannelRegistration registration) {
+		registration.interceptors(stompHandler);
 	}
 }

--- a/src/main/java/com/zunza/buythedip/security/exception/StompAuthenticationException.java
+++ b/src/main/java/com/zunza/buythedip/security/exception/StompAuthenticationException.java
@@ -1,0 +1,17 @@
+package com.zunza.buythedip.security.exception;
+
+import com.zunza.buythedip.common.CustomException;
+
+public class StompAuthenticationException extends CustomException {
+
+	private static final String MESSAGE = "인증이 필요한 작업입니다.";
+
+	public StompAuthenticationException() {
+		super(MESSAGE);
+	}
+
+	@Override
+	public int getStatusCode() {
+		return 401;
+	}
+}

--- a/src/main/java/com/zunza/buythedip/security/exception/StompAuthorizationHeaderException.java
+++ b/src/main/java/com/zunza/buythedip/security/exception/StompAuthorizationHeaderException.java
@@ -1,0 +1,17 @@
+package com.zunza.buythedip.security.exception;
+
+import com.zunza.buythedip.common.CustomException;
+
+public class StompAuthorizationHeaderException extends CustomException {
+
+	private static final String MESSAGE = "Stomp 인증 헤더가 필요합니다.";
+
+	public StompAuthorizationHeaderException() {
+		super(MESSAGE);
+	}
+
+	@Override
+	public int getStatusCode() {
+		return 401;
+	}
+}

--- a/src/main/java/com/zunza/buythedip/security/exception/StompInvalidTokenException.java
+++ b/src/main/java/com/zunza/buythedip/security/exception/StompInvalidTokenException.java
@@ -1,0 +1,17 @@
+package com.zunza.buythedip.security.exception;
+
+import com.zunza.buythedip.common.CustomException;
+
+public class StompInvalidTokenException extends CustomException {
+
+	private static final String MESSAGE = "인증 헤더의 값은 'Bearer [토큰]' 형식이어야 합니다.";
+
+	public StompInvalidTokenException() {
+		super(MESSAGE);
+	}
+
+	@Override
+	public int getStatusCode() {
+		return 401;
+	}
+}


### PR DESCRIPTION
이전에 SecurityConfig에서 SockJS 핸드셰이크를 위해 /ws-chat/** 경로를 permitAll()로 설정
인터셉터 설정을 통해 핸드셰이크는 통과되더라도 실질적인 STOMP 통신은 반드시 인증된 사용자만 가능하도록 함