### PR TITLE
feat: Redis Streams를 버퍼로 사용하여 채팅 메시지를 MongoDB에 배치 저장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 
 	// querydsl
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'

--- a/src/main/java/com/zunza/buythedip/chat/controller/ChatController.java
+++ b/src/main/java/com/zunza/buythedip/chat/controller/ChatController.java
@@ -1,10 +1,14 @@
 package com.zunza.buythedip.chat.controller;
 
+import java.security.Principal;
+
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.zunza.buythedip.chat.dto.ChatMessageDto;
 import com.zunza.buythedip.chat.service.ChatService;
+import com.zunza.buythedip.security.CustomUserDetails;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,8 +22,16 @@ public class ChatController {
 
 	@MessageMapping("/chat/room/public")
 	public void sendMessage(
-		ChatMessageDto chatMessageDto
+		ChatMessageDto chatMessageDto,
+		Principal principal
 	) {
-		chatService.sendMessage(chatMessageDto);
+		String accountId = getAccountId(principal);
+		chatService.sendMessage(accountId, chatMessageDto);
+	}
+
+	private String getAccountId(Principal principal) {
+		Authentication auth = (Authentication)principal;
+		CustomUserDetails details = (CustomUserDetails)auth.getPrincipal();
+		return details.getUsername();
 	}
 }

--- a/src/main/java/com/zunza/buythedip/chat/entity/ChatMessage.java
+++ b/src/main/java/com/zunza/buythedip/chat/entity/ChatMessage.java
@@ -1,0 +1,39 @@
+package com.zunza.buythedip.chat.entity;
+
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Document(collection = "chat_messages")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage {
+
+	@Id
+	private String id;
+	private String accountId;
+	private String sender;
+	private String content;
+	private long timestamp;
+
+	@Builder
+	private ChatMessage(String accountId, String sender, String content, long timestamp) {
+		this.accountId = accountId;
+		this.sender = sender;
+		this.content = content;
+		this.timestamp = timestamp;
+	}
+
+	public static ChatMessage of(String accountId, String sender, String content, long timestamp) {
+		return ChatMessage.builder()
+			.accountId(accountId)
+			.sender(sender)
+			.content(content)
+			.timestamp(timestamp)
+			.build();
+	}
+}

--- a/src/main/java/com/zunza/buythedip/chat/service/ChatMessageBatchService.java
+++ b/src/main/java/com/zunza/buythedip/chat/service/ChatMessageBatchService.java
@@ -1,0 +1,74 @@
+package com.zunza.buythedip.chat.service;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.StreamReadOptions;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import com.zunza.buythedip.chat.entity.ChatMessage;
+import com.zunza.buythedip.infrastructure.redis.RedisStreamService;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatMessageBatchService {
+
+	private final MongoTemplate mongoTemplate;
+	private final RedisStreamService redisStreamService;
+
+	private static final String STREAM_KEY = "chat:stream";
+	private static final String GROUP_NAME = "chat-group";
+	private static final String CONSUMER_NAME = "server-" + UUID.randomUUID();
+
+	@PostConstruct
+	public void init() {
+		try {
+			redisStreamService.createGroup(STREAM_KEY, GROUP_NAME);
+		} catch (Exception e) {
+			log.info("Consumer group '{}' already exists.", GROUP_NAME);
+		}
+	}
+
+	@Scheduled(fixedRate = 10000)
+	public void processChatMessage() {
+		StreamReadOptions readOptions = StreamReadOptions.empty()
+			.count(50)
+			.block(Duration.ofSeconds(2));
+
+		List<MapRecord<String, Object, Object>> messages = redisStreamService.read(GROUP_NAME, CONSUMER_NAME, readOptions, STREAM_KEY);
+
+		if (messages == null || messages.isEmpty()) {
+			return;
+		}
+
+		List<ChatMessage> chatMessages = convertToDocuments(messages);
+		mongoTemplate.insertAll(chatMessages);
+
+		for (MapRecord<String, Object, Object> message : messages) {
+			redisStreamService.ack(STREAM_KEY, GROUP_NAME, message.getId());
+		}
+	}
+
+	private List<ChatMessage> convertToDocuments(List<MapRecord<String, Object, Object>> messages) {
+		return messages.stream()
+			.map(record -> {
+				Map<Object, Object> value = record.getValue();
+				return ChatMessage.of(
+					(String)value.get("accountId"),
+					(String)value.get("sender"),
+					(String)value.get("content"),
+					Long.parseLong((String)value.get("timestamp")));
+			})
+			.toList();
+	}
+}

--- a/src/main/java/com/zunza/buythedip/chat/service/ChatService.java
+++ b/src/main/java/com/zunza/buythedip/chat/service/ChatService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 
 import com.zunza.buythedip.chat.dto.ChatMessageDto;
 import com.zunza.buythedip.infrastructure.redis.RedisMessagePublisher;
+import com.zunza.buythedip.infrastructure.redis.RedisStreamService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -12,8 +13,10 @@ import lombok.RequiredArgsConstructor;
 public class ChatService {
 
 	private final RedisMessagePublisher redisMessagePublisher;
+	private final RedisStreamService redisStreamService;
 
-	public void sendMessage(ChatMessageDto chatMessageDto) {
+	public void sendMessage(String accountId, ChatMessageDto chatMessageDto) {
 		redisMessagePublisher.publishMessage(chatMessageDto);
+		redisStreamService.addToStream(accountId, chatMessageDto);
 	}
 }

--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/RedisStreamService.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/RedisStreamService.java
@@ -1,0 +1,59 @@
+package com.zunza.buythedip.infrastructure.redis;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.data.redis.connection.stream.Consumer;
+import org.springframework.data.redis.connection.stream.MapRecord;
+import org.springframework.data.redis.connection.stream.ReadOffset;
+import org.springframework.data.redis.connection.stream.RecordId;
+import org.springframework.data.redis.connection.stream.StreamOffset;
+import org.springframework.data.redis.connection.stream.StreamReadOptions;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.zunza.buythedip.chat.dto.ChatMessageDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RedisStreamService {
+
+	private final RedisTemplate<String, Object> redisTemplate;
+	private static final String STREAM_KEY = "chat:stream";
+
+	public void addToStream(String accountId, ChatMessageDto chatMessageDto) {
+		Map<String, String> messageMap = converToMap(accountId, chatMessageDto);
+		redisTemplate.opsForStream().add(STREAM_KEY, messageMap);
+	}
+
+	private Map<String, String> converToMap(String accountId, ChatMessageDto chatMessageDto) {
+		Map<String, String> map = new HashMap<>();
+		map.put("accountId", accountId);
+		map.put("sender", chatMessageDto.getSender());
+		map.put("content", chatMessageDto.getContent());
+		map.put("timestamp", String.valueOf(chatMessageDto.getTimestamp()));
+		return map;
+	}
+
+	public void createGroup(String key, String group) {
+		redisTemplate.opsForStream()
+			.createGroup(key, ReadOffset.from("0"), group);
+	}
+
+	public List<MapRecord<String, Object, Object>> read(String group, String consumer,
+		StreamReadOptions readOptions, String key) {
+
+		return redisTemplate.opsForStream().read(
+			Consumer.from(group, consumer),
+			readOptions,
+			StreamOffset.create(key, ReadOffset.lastConsumed())
+		);
+	}
+
+	public void ack(String key, String group, RecordId id) {
+		redisTemplate.opsForStream().acknowledge(key, group, id);
+	}
+}


### PR DESCRIPTION
- ChatService는 메시지 수신 시, 기존처럼 Redis Pub/Sub으로 실시간 전송을 수행함과 동시에 Redis Streams (XADD)에 메시지를 기록
- @Scheduled를 이용한 ChatMessageBatchService가 10초마다 Redis Streams에 쌓인 메시지를 Consumer Group을 통해 읽음
- Consumer Group을 사용하여 스케일 아웃에 대비하고, 메시지 처리 상태(ACK)를 관리하여 데이터 유실 및 중복 처리를 방지
- 배치 프로세서는 읽어온 메시지들을 묶어서(insertAll) MongoDB에 저장하여 DB 쓰기 부하를 최소화