### PR TITLE
perf: Redis ZSET과 @Cacheable을 이용한 뉴스 API 캐싱 적용 및 성능 최적화

### DIFF
--- a/src/main/java/com/zunza/buythedip/config/CacheConfig.java
+++ b/src/main/java/com/zunza/buythedip/config/CacheConfig.java
@@ -1,0 +1,42 @@
+package com.zunza.buythedip.config;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.zunza.buythedip.constant.CacheType;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+	@Bean
+	public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+		RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+			.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+			.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+		Map<String, RedisCacheConfiguration> cacheConfigurations = Stream.of(CacheType.values())
+			.collect(Collectors.toMap(
+				CacheType::getCacheName,
+				cacheType -> defaultConfig.entryTtl(cacheType.getExpiredAfterWrite())
+			));
+
+		return RedisCacheManager.builder(redisConnectionFactory)
+			.cacheDefaults(defaultConfig.entryTtl(Duration.ofMinutes(1)))
+			.withInitialCacheConfigurations(cacheConfigurations)
+			.build();
+	}
+}

--- a/src/main/java/com/zunza/buythedip/constant/CacheNames.java
+++ b/src/main/java/com/zunza/buythedip/constant/CacheNames.java
@@ -1,0 +1,7 @@
+package com.zunza.buythedip.constant;
+
+public class CacheNames {
+	public static final String NEWS_DETAIL = "news-detail";
+	public static final String CRYPTO_DATA_WITH_LOGO = "crypto-data-with-logo";
+	public static final String CRYPTO_INFO = "crypto-info";
+}

--- a/src/main/java/com/zunza/buythedip/constant/CacheType.java
+++ b/src/main/java/com/zunza/buythedip/constant/CacheType.java
@@ -1,0 +1,17 @@
+package com.zunza.buythedip.constant;
+
+import java.time.Duration;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CacheType {
+	NEWS_DETAIL(CacheNames.NEWS_DETAIL, Duration.ofMinutes(10)),
+	CRYPTO_DATA_WITH_LOGO(CacheNames.CRYPTO_DATA_WITH_LOGO, Duration.ofMinutes(60)),
+	CRYPTO_INFO(CacheNames.CRYPTO_INFO, Duration.ofMinutes(10));
+
+	private final String cacheName;
+	private final Duration expiredAfterWrite;
+}

--- a/src/main/java/com/zunza/buythedip/news/service/NewsCacheService.java
+++ b/src/main/java/com/zunza/buythedip/news/service/NewsCacheService.java
@@ -1,0 +1,92 @@
+package com.zunza.buythedip.news.service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zunza.buythedip.news.dto.NewsListResponseDto;
+import com.zunza.buythedip.news.entity.News;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NewsCacheService {
+
+	private final ObjectMapper objectMapper;
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	private static final String NEWS_FEED_KEY = "news:feed";
+	private static final String NEWS_DATA_KEY_PREFIX = "news:data:";
+	private static final int MAX_CACHED_NEWS = 150;
+
+	public void cacheNewsList(List<News> newsList) {
+		List<NewsListResponseDto> newsListResponseDto = newsList.stream()
+			.map(NewsListResponseDto::from)
+			.toList();
+
+		addToCache(newsListResponseDto);
+		trimOldNews();
+	}
+
+	public List<NewsListResponseDto> getCachedNewsList(Long cursor, int size) {
+		Set<Object> newsIds;
+
+		if (cursor == null) {
+			newsIds = redisTemplate.opsForZSet().reverseRange(NEWS_FEED_KEY, 0, size - 1);
+		} else {
+			newsIds = redisTemplate.opsForZSet().reverseRangeByScore(NEWS_FEED_KEY, 0, cursor - 1, 0, size);
+		}
+
+		if (newsIds == null || newsIds.isEmpty()) {
+			log.info("News List Cache Miss!");
+			return Collections.emptyList();
+		}
+
+		log.info("News List Cache Hit!");
+		return newsIds.stream()
+			.map(id -> getNewsData(id.toString()))
+			.toList();
+	}
+
+	public void cacheMissedNews(List<NewsListResponseDto> newsListResponseDto) {
+		log.info("try cache missed news!");
+		addToCache(newsListResponseDto);
+	}
+
+	private void addToCache(List<NewsListResponseDto> newsListResponseDto) {
+		newsListResponseDto.forEach(dto -> {
+			redisTemplate.opsForZSet().add(NEWS_FEED_KEY, dto.getId(), dto.getDatetime());
+			redisTemplate.opsForValue().set(NEWS_DATA_KEY_PREFIX + dto.getId(), dto);
+		});
+	}
+
+	private void trimOldNews() {
+		Long currentSize = redisTemplate.opsForZSet().size(NEWS_FEED_KEY);
+
+		if (MAX_CACHED_NEWS >= currentSize) {
+			return;
+		}
+
+		long removeCount = currentSize - MAX_CACHED_NEWS;
+
+		Set<Object> oldNewsIds = redisTemplate.opsForZSet().range(NEWS_FEED_KEY, 0, removeCount - 1);
+		List<String> keysToRemove = oldNewsIds.stream()
+			.map(id -> NEWS_DATA_KEY_PREFIX + id)
+			.toList();
+
+		redisTemplate.delete(keysToRemove);
+		redisTemplate.opsForZSet().removeRange(NEWS_FEED_KEY, 0, removeCount - 1);
+	}
+
+	private NewsListResponseDto getNewsData(String newsId) {
+		Object dto = redisTemplate.opsForValue().get(NEWS_DATA_KEY_PREFIX + newsId);
+		return objectMapper.convertValue(dto, NewsListResponseDto.class);
+	}
+}

--- a/src/main/java/com/zunza/buythedip/news/service/NewsService.java
+++ b/src/main/java/com/zunza/buythedip/news/service/NewsService.java
@@ -2,8 +2,10 @@ package com.zunza.buythedip.news.service;
 
 import java.util.List;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
+import com.zunza.buythedip.constant.CacheNames;
 import com.zunza.buythedip.news.dto.NewsDetailResponseDto;
 import com.zunza.buythedip.news.dto.NewsListResponseDto;
 import com.zunza.buythedip.news.entity.News;
@@ -22,6 +24,7 @@ public class NewsService {
 		return newsRepository.findByCursor(cursor, size);
 	}
 
+	@Cacheable(value = CacheNames.NEWS_DETAIL, key = "#newsId")
 	public NewsDetailResponseDto getNews(Long newsId) {
 		News news = newsRepository.findById(newsId)
 			.orElseThrow(() -> new NewsNotFoundException(newsId));

--- a/src/main/java/com/zunza/buythedip/news/service/StorageService.java
+++ b/src/main/java/com/zunza/buythedip/news/service/StorageService.java
@@ -17,12 +17,14 @@ import lombok.RequiredArgsConstructor;
 public class StorageService {
 
 	private final NewsRepository newsRepository;
+	private final NewsCacheService newsCacheService;
 
 	@RabbitListener(queues = RabbitMQConstants.NEWS_STORAGE_QUEUE)
 	public void saveNews(List<NewsDto> translatedNewsDtoList) {
 		List<News> newsList = translatedNewsDtoList.stream()
 			.map(News::from)
 			.toList();
-		newsRepository.saveAll(newsList);
+		List<News> saved = newsRepository.saveAll(newsList);
+		newsCacheService.cacheNewsList(saved);
 	}
 }


### PR DESCRIPTION
1. 뉴스 목록: Redis ZSET을 이용한 수동 캐싱
- List 객체를 통째로 캐싱할 경우, 새로운 뉴스가 추가될 때마다 전체 캐시를 무효화하고 새로 캐싱 해야함
- ZSET을 사용하여 뉴스 목록의 순서 정보만 별도로 관리하고, 실제 데이터는 개별 키에 저장
- ZSET (news:feed): member에는 newsId를, score에는 정렬 기준인 datetime(타임스탬프)을 저장하여 최신순 정렬
- String (news:data:{id}): 개별 뉴스 데이터 저장
- 새로운 뉴스가 저장될 때마다, 기존 캐시를 삭제하는 대신 ZADD와 SET 명령으로 새로운 뉴스 데이터만 캐시
- TTL을 설정하는 대신, 최대 N개의 캐시만 유지
- 캐시 크기가 N개를 초과하면, ZREMRANGE와 DEL을 이용해 가장 오래된 뉴스를 캐시에서 제거

2. 뉴스 상세: @Cacheable을 이용한 단순 캐싱 적용
- 내용이 거의 변하지 않는 뉴스 상세 데이터의 특성을 고려하여 @Cacheable 어노테이션을 사용
- NewsService의 getNews(newsId) 메서드에 적용하여, newsId를 키로 하는 캐시를 10분간 유지