### PR TITLE
feat: 실시간 거래대금 집계(30분) 구현

### DIFF
--- a/src/main/java/com/zunza/buythedip/cryptocurrency/service/TradeAggregationService.java
+++ b/src/main/java/com/zunza/buythedip/cryptocurrency/service/TradeAggregationService.java
@@ -1,0 +1,50 @@
+package com.zunza.buythedip.cryptocurrency.service;
+
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.zunza.buythedip.constant.RabbitMQConstants;
+import com.zunza.buythedip.cryptocurrency.dto.binance.TradeDto;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TradeAggregationService {
+
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	private static final long BUCKET_TTL_MINUTE = 31L;
+	private static final String MINUTE_BUCKET_KEY_PREFIX = "tv:";
+
+	@RabbitListener(queues = RabbitMQConstants.TRADE_AGGREGATION_QUEUE)
+	public void aggregateVolumeLast30Minutes(TradeDto tradeDto) {
+		try {
+			String bucketKey = generateCurrentMinuteBucketKey(tradeDto.getTradeTime());
+			double volume = tradeDto.getPrice() * tradeDto.getQuantity();
+
+			redisTemplate.opsForZSet().incrementScore(bucketKey, tradeDto.getSymbol(), volume);
+			redisTemplate.expire(bucketKey, Duration.ofMinutes(BUCKET_TTL_MINUTE));
+
+		} catch (Exception e) {
+			log.error(e.getMessage());
+		}
+	}
+
+	private String generateCurrentMinuteBucketKey(Long tradeTime) {
+		Instant tradeInstant = Instant.ofEpochMilli(tradeTime);
+		LocalDateTime tradeDateTime = LocalDateTime.ofInstant(tradeInstant, ZoneId.of("UTC"));
+
+		return  MINUTE_BUCKET_KEY_PREFIX + tradeDateTime.format(DateTimeFormatter.ofPattern("yyyyMMddHHmm"));
+	}
+}


### PR DESCRIPTION
실시간으로 누적되는 거래대금을 최근 30분 기준으로 상위 N개 종목을 선정하기 위한 기반 데이터 집계 기능을 추가

1. 메시지 수신
- trade-aggregation-queue를 통해 실시간 체결 데이터를 수신

2. 1분 단위 버킷
- 수신된 데이터의 거래 시간을 기준으로, 현재 데이터가 속해야 할 1분 단위의 버킷 키(Bucket Key)를 생성 (예: tv:202501281530)
- 각 암호화폐마다 특정 1분 동안 발생한 모든 거래를 하나의 Redis 키 아래에 그룹화

3. Redis ZSET을 이용한 누적 합산
- 각 버킷 키는 Redis ZSET(Sorted Set) 자료구조를 사용
- member: 암호화폐 심볼 (예: BTCUSDT) / score: 해당 1분 동안의 누적 거래대금 (price * quantity)
- ZINCRBY 명령을 사용하여, 새로운 거래가 발생할 때마다 해당 심볼의 score를 원자적으로 증가

4. TTL
- 각 1분 단위 버킷 키에는 31분의 TTL을 설정
- 이 방식을 통해, 별도의 삭제 로직 없이도 항상 최근 약 30분간의 데이터만을 Redis에 유지