### PR TITLE
feat: 실시간 거래대금 랭킹 및 랭킹 내 종목의 시세 정보 브로드캐스팅 구현

### DIFF
--- a/src/main/java/com/zunza/buythedip/cryptocurrency/scheduler/UpdateVolumeScheduler.java
+++ b/src/main/java/com/zunza/buythedip/cryptocurrency/scheduler/UpdateVolumeScheduler.java
@@ -1,0 +1,79 @@
+package com.zunza.buythedip.cryptocurrency.scheduler;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import com.zunza.buythedip.cryptocurrency.service.broadcast.TopTradingBroadcastService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UpdateVolumeScheduler {
+
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final TopTradingBroadcastService topTradingBroadcastService;
+
+	private static final String MINUTE_BUCKET_KEY_PREFIX = "tv:";
+	private static final String AGGREGATED_VOLUME_KEY = MINUTE_BUCKET_KEY_PREFIX + "30m_aggregated";
+	private static final String CACHE_TOP_VOLUME_KEY = "cache:topVolume";
+
+	private static final int AGGREGATION_WINDOW_MINUTES = 30;
+	private static final int TOP_N = 50;
+
+	@Scheduled(fixedRate = 10000)
+	public void updateVolumeData() {
+		aggregateVolumeData();
+		Set<ZSetOperations.TypedTuple<Object>> topNVolumeSet = getTopNVolumeSet(TOP_N);
+
+		if (topNVolumeSet == null || topNVolumeSet.isEmpty()) {
+			log.info("No Volume Data");
+			return;
+		}
+
+		topTradingBroadcastService.broadcastTopTradingVolumeRanking(topNVolumeSet);
+		cacheTopVolume(topNVolumeSet);
+	}
+
+	private void aggregateVolumeData() {
+		List<String> keys = generateKeysForLastNMinutes(AGGREGATION_WINDOW_MINUTES);
+
+		if (keys == null || keys.isEmpty()) {
+			return;
+		}
+
+		redisTemplate.opsForZSet().unionAndStore(keys.get(0), keys.subList(1, keys.size()), AGGREGATED_VOLUME_KEY);
+	}
+
+	private List<String> generateKeysForLastNMinutes(int minutes) {
+		ZonedDateTime utc = ZonedDateTime.now(ZoneId.of("UTC"));
+		return IntStream.range(0, minutes)
+			.mapToObj(i -> utc.minusMinutes(i).format(DateTimeFormatter.ofPattern("yyyyMMddHHmm")))
+			.map(time -> MINUTE_BUCKET_KEY_PREFIX + time)
+			.toList();
+	}
+
+	private Set<ZSetOperations.TypedTuple<Object>> getTopNVolumeSet(int n) {
+		return redisTemplate.opsForZSet().reverseRangeWithScores(AGGREGATED_VOLUME_KEY, 0, n - 1);
+	}
+
+	private void cacheTopVolume(Set<ZSetOperations.TypedTuple<Object>> topNVolumeSet) {
+		Set<String> set = topNVolumeSet.stream()
+			.map(tuple -> tuple.getValue().toString())
+			.collect(Collectors.toSet());
+
+		redisTemplate.opsForValue().set(CACHE_TOP_VOLUME_KEY, set);
+	}
+}

--- a/src/main/java/com/zunza/buythedip/cryptocurrency/service/broadcast/TopTradingBroadcastService.java
+++ b/src/main/java/com/zunza/buythedip/cryptocurrency/service/broadcast/TopTradingBroadcastService.java
@@ -1,0 +1,96 @@
+package com.zunza.buythedip.cryptocurrency.service.broadcast;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+
+import com.zunza.buythedip.constant.ChannelNames;
+import com.zunza.buythedip.constant.RabbitMQConstants;
+import com.zunza.buythedip.infrastructure.redis.RedisMessagePublisher;
+import com.zunza.buythedip.cryptocurrency.dto.CryptoDataWithLogoDto;
+import com.zunza.buythedip.cryptocurrency.dto.RankingDto;
+import com.zunza.buythedip.cryptocurrency.dto.RealtimePriceDto;
+import com.zunza.buythedip.cryptocurrency.dto.binance.TradeDto;
+import com.zunza.buythedip.cryptocurrency.repository.CryptocurrencyRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TopTradingBroadcastService {
+
+	private final CryptocurrencyRepository cryptocurrencyRepository;
+	private final RedisMessagePublisher redisMessagePublisher;
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	private static final String OPEN_PRICE_KEY_SUFFIX = ":OPENPRICE";
+
+	public void broadcastTopTradingVolumeRanking(Set<ZSetOperations.TypedTuple<Object>> TopNVolumeSet) {
+		try {
+			Map<String, CryptoDataWithLogoDto> cryptoMap = cryptocurrencyRepository.findAllWithLogo()
+				.stream()
+				.collect(Collectors.toMap(CryptoDataWithLogoDto::getSymbol, c -> c));
+
+			List<RankingDto> res = TopNVolumeSet.stream()
+				.map(tuple -> {
+					String symbol = tuple.getValue().toString().replace("USDT", "");
+					CryptoDataWithLogoDto crypto = cryptoMap.get(symbol);
+
+					return RankingDto.of(
+						crypto.getId(),
+						crypto.getName(),
+						crypto.getSymbol(),
+						crypto.getLogo(),
+						Double.parseDouble(tuple.getScore().toString()));
+				})
+				.toList();
+
+			redisMessagePublisher.publishMessage(ChannelNames.TOP_VOLUME_TOPIC, res);
+			log.info("Successfully published updated TopVolume Ranking");
+
+		} catch (Exception e) {
+			log.error("Failed to serialize ranking data to JSON.", e);
+			log.error(e.getMessage());
+		}
+	}
+
+	@RabbitListener(queues = RabbitMQConstants.TOP_VOLUME_TICKER_BROADCAST_QUEUE)
+	public void broadcastTopTradingVolumeTickers(TradeDto tradeDto) {
+		try {
+			String symbol = tradeDto.getSymbol();
+
+			RealtimePriceDto realtimePriceDto = RealtimePriceDto.of(
+				extractBaseCurrency(symbol),
+				tradeDto.getPrice(),
+				getChangeRate(symbol, tradeDto.getPrice())
+			);
+
+			redisMessagePublisher.publishMessage(ChannelNames.TOP_PRICE_TICK_TOPIC, realtimePriceDto);
+
+		} catch (Exception e) {
+			log.error(e.getMessage());
+		}
+	}
+
+	private String extractBaseCurrency(String symbol) {
+		return symbol.replace("USDT", "");
+	}
+
+	private double getOpenPrice(String symbol) {
+		String openPriceStr = redisTemplate.opsForValue().get(symbol + OPEN_PRICE_KEY_SUFFIX).toString();
+		return Double.parseDouble(openPriceStr);
+	}
+
+	private double getChangeRate(String symbol, double currentPrice) {
+		double openPrice = getOpenPrice(symbol);
+		return ((currentPrice - openPrice) / openPrice) * 100;
+	}
+}


### PR DESCRIPTION
1. 랭킹 집계 및 발행 (UpdateVolumeScheduler)
- @Scheduled(fixedRate = 10000)를 통해 10초마다 updateVolumeData 메서드가 실행됩니다.
- Redis ZUNIONSTORE 명령을 사용하여, 최근 30분 동안의 1분 단위 버킷들을 하나의 통합된 ZSET(tv:30m_aggregated)으로 합산. 이 과정을 통해 각 종목의 "최근 30분 누적 거래대금"이 계산됨
- 통합된 ZSET(tv:30m_aggregated)에서 reverseRangeWithScores를 이용해 거래대금이 가장 높은 상위 N개 종목의 목록(symbol, score)을 추출
- 추출된 랭킹 데이터를 TopTradingBroadcastService로 전달하여, DB에서 로고 등 추가 정보를 결합한 후, 전체 랭킹 목록을 Redis Pub/Sub(/topic/crypto/volume/top)을 통해 발행
- Top N 목록 캐싱: 실시간 시세 발행에서 사용하기 위해, 상위 50개 종목의 심볼 목록(Set<String>)을 Redis에 별도로 캐싱

2. 실시간 시세 발행 (TopTradingBroadcastService)
- BinanceMessageRouter를 통해 거래대금 상위 종목에 대한 체결 데이터만 이 서비스의 RabbitMQ 큐로 전달
- 수신된 체결 데이터를 기반으로, 당일 시가(Open Price) 대비 등락률을 계산합니다.
- 실시간 가격 정보를 Redis Pub/Sub의 개별 시세 토픽(/topic/crypto/price/top)으로 발행
