### PR TITLE
feat: 종목별 시세 정보 브로드캐스팅

### DIFF
--- a/src/main/java/com/zunza/buythedip/cryptocurrency/service/broadcast/SymbolTickerBroadcastService.java
+++ b/src/main/java/com/zunza/buythedip/cryptocurrency/service/broadcast/SymbolTickerBroadcastService.java
@@ -1,0 +1,64 @@
+package com.zunza.buythedip.cryptocurrency.service.broadcast;
+
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.zunza.buythedip.constant.ChannelNames;
+import com.zunza.buythedip.constant.RabbitMQConstants;
+import com.zunza.buythedip.infrastructure.redis.RedisMessagePublisher;
+import com.zunza.buythedip.cryptocurrency.dto.SymbolTickerDto;
+import com.zunza.buythedip.cryptocurrency.dto.binance.TradeDto;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SymbolTickerBroadcastService {
+
+	private final RedisMessagePublisher redisMessagePublisher;
+	private final RedisTemplate<String, Object> redisTemplate;
+
+
+	private static final String OPEN_PRICE_KEY_SUFFIX = ":OPENPRICE";
+
+
+	@RabbitListener(queues = RabbitMQConstants.SYMBOL_TICKER_BROADCAST_QUEUE)
+	public void broadcastSymbolTicker(TradeDto tradeDto) {
+		try {
+			String symbol = tradeDto.getSymbol();
+
+			double currentPrice = tradeDto.getPrice();
+			double changePrice = getChangePrice(symbol, currentPrice);
+			double changeRate = getChangeRate(symbol, currentPrice);
+			String baseSymbol = extractBaseCurrency(symbol);
+
+			SymbolTickerDto symbolTickerDto = SymbolTickerDto.of(baseSymbol, currentPrice, changePrice, changeRate);
+
+			redisMessagePublisher.publishMessage(ChannelNames.SYMBOL_TICKER_TOPIC, symbolTickerDto);
+
+		} catch (Exception e) {
+			log.error(e.getMessage());
+		}
+	}
+
+	private double getOpenPrice(String symbol) {
+		return (double)redisTemplate.opsForValue().get(symbol + OPEN_PRICE_KEY_SUFFIX);
+	}
+
+	private double getChangePrice(String symbol, double currentPrice) {
+		double openPrice = getOpenPrice(symbol);
+		return currentPrice - openPrice;
+	}
+
+	private double getChangeRate(String symbol, double currentPrice) {
+		double openPrice = getOpenPrice(symbol);
+		return ((currentPrice - openPrice) / openPrice) * 100;
+	}
+
+	private String extractBaseCurrency(String symbol) {
+		return symbol.replace("USDT", "");
+	}
+}


### PR DESCRIPTION
1. 선별적 메시지 수신
- 클라이언트가 특정 종목의 상세 페이지에 진입하면, 해당 종목의 STOMP 토픽(/topic/crypto/symbol/{symbol} 을 구독
- SymbolTickerBroadcastHandler는 Redis에 저장된 구독자 수를 확인하여, 현재 구독 중인 종목에 대한 체결 데이터만 symbol-ticker-broadcast-queue로 라우팅

2. 실시간 데이터 가공 (SymbolTickerBroadcastService):
- RabbitMQ로부터 수신한 체결 데이터를 기반으로 다음과 같은 실시간 지표를 계산
  - 변동 금액: 현재가 - 당일 시가(Open Price)
  - 등락률: (현재가 - 당일 시가) / 당일 시가 * 100
- 당일 시가 데이터는 매일 00:00(UTC) 에 스케줄러를 통해 Redis에 미리 캐싱된 값을 사용

3. 데이터 발행:
- 계산된 모든 정보(심볼, 현재가, 변동 금액, 등락률)를 SymbolTickerDto에 담아 발행