### PR TITLE
feat: RedisMessageSubscriber를 라우터로 활용하여 핸들러 로직 분리

### DIFF
--- a/src/main/java/com/zunza/buythedip/constant/ChannelNames.java
+++ b/src/main/java/com/zunza/buythedip/constant/ChannelNames.java
@@ -1,0 +1,10 @@
+package com.zunza.buythedip.constant;
+
+
+
+public class ChannelNames {
+	public static final String CHAT_MESSAGE_TOPIC = "chat:message";
+	public static final String TOP_PRICE_TICK_TOPIC = "realtime:topN:price";
+	public static final String TOP_VOLUME_TOPIC = "topN:volume";
+	public static final String SYMBOL_TICKER_TOPIC = "symbol:ticker";
+}

--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/RedisMessagePublisher.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/RedisMessagePublisher.java
@@ -1,10 +1,8 @@
 package com.zunza.buythedip.infrastructure.redis;
 
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.stereotype.Service;
 
-import com.zunza.buythedip.chat.dto.ChatMessageDto;
 
 import lombok.RequiredArgsConstructor;
 
@@ -13,9 +11,8 @@ import lombok.RequiredArgsConstructor;
 public class RedisMessagePublisher {
 
 	private final RedisTemplate<String, Object> redisTemplate;
-	private final ChannelTopic channelTopic;
 
-	public void publishMessage(ChatMessageDto chatMessageDto) {
-		redisTemplate.convertAndSend(channelTopic.getTopic(), chatMessageDto);
+	public void publishMessage(String topic, Object message) {
+		redisTemplate.convertAndSend(topic, message);
 	}
 }

--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/RedisMessageSubscriber.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/RedisMessageSubscriber.java
@@ -1,28 +1,41 @@
 package com.zunza.buythedip.infrastructure.redis;
 
-import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import java.util.Map;
+
 import org.springframework.stereotype.Service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.zunza.buythedip.chat.dto.ChatMessageDto;
+import com.zunza.buythedip.constant.ChannelNames;
+import com.zunza.buythedip.infrastructure.redis.subhandle.ChatHandler;
+import com.zunza.buythedip.infrastructure.redis.subhandle.RedisMessageHandler;
+import com.zunza.buythedip.infrastructure.redis.subhandle.SymbolTickerHandler;
+import com.zunza.buythedip.infrastructure.redis.subhandle.TopVolumeHandler;
+import com.zunza.buythedip.infrastructure.redis.subhandle.TopVolumePriceHandler;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class RedisMessageSubscriber {
 
-	private final ObjectMapper objectMapper;
-	private final SimpMessageSendingOperations messagingTemplate;
-	private static final String DESTINATION = "/topic/chat/room/public";
+	private final Map<String, RedisMessageHandler> handleMap;
 
-	public void sendMessage(String publishMessage) {
+	public RedisMessageSubscriber(
+		ChatHandler chatHandler,
+		TopVolumeHandler topVolumeHandler,
+		TopVolumePriceHandler topVolumePriceHandler,
+		SymbolTickerHandler symbolTickerHandler
+	) {
+		this.handleMap = Map.of(
+			ChannelNames.CHAT_MESSAGE_TOPIC, chatHandler,
+			ChannelNames.TOP_VOLUME_TOPIC, topVolumeHandler,
+			ChannelNames.TOP_PRICE_TICK_TOPIC, topVolumePriceHandler,
+			ChannelNames.SYMBOL_TICKER_TOPIC, symbolTickerHandler
+		);
+	}
+
+	public void sendMessage(String message, String channel) {
 		try {
-			ChatMessageDto chatMessageDto = objectMapper.readValue(publishMessage, ChatMessageDto.class);
-			messagingTemplate.convertAndSend(DESTINATION, chatMessageDto);
-
+			handleMap.get(channel).handle(message);
 		} catch (Exception e) {
 			log.error("Error processing message from Redis Pub/Sub: {}", e.getMessage(), e);
 		}

--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/subhandle/ChatHandler.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/subhandle/ChatHandler.java
@@ -1,0 +1,26 @@
+package com.zunza.buythedip.infrastructure.redis.subhandle;
+
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zunza.buythedip.chat.dto.ChatMessageDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class ChatHandler implements RedisMessageHandler {
+
+	private final ObjectMapper objectMapper;
+	private final SimpMessageSendingOperations messagingTemplate;
+
+	private static final String CHAT_DESTINATION = "/topic/chat/room/public";
+
+	@Override
+	public void handle(String message) throws JsonProcessingException {
+		ChatMessageDto chatMessageDto = objectMapper.readValue(message, ChatMessageDto.class);
+		messagingTemplate.convertAndSend(CHAT_DESTINATION, chatMessageDto);
+	}
+}

--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/subhandle/RedisMessageHandler.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/subhandle/RedisMessageHandler.java
@@ -1,0 +1,7 @@
+package com.zunza.buythedip.infrastructure.redis.subhandle;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public interface RedisMessageHandler {
+	void handle(String message) throws JsonProcessingException;
+}

--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/subhandle/SymbolTickerHandler.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/subhandle/SymbolTickerHandler.java
@@ -1,0 +1,27 @@
+package com.zunza.buythedip.infrastructure.redis.subhandle;
+
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zunza.buythedip.cryptocurrency.dto.SymbolTickerDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SymbolTickerHandler implements RedisMessageHandler{
+
+	private final ObjectMapper objectMapper;
+	private final SimpMessageSendingOperations messagingTemplate;
+
+	private static final String SYMBOL_TICKER_DESTINATION_PREFIX = "/topic/crypto/symbol/";
+
+	@Override
+	public void handle(String message) throws JsonProcessingException {
+		SymbolTickerDto symbolTickerDto = objectMapper.readValue(message, SymbolTickerDto.class);
+		String destination = SYMBOL_TICKER_DESTINATION_PREFIX + symbolTickerDto.getSymbol();
+		messagingTemplate.convertAndSend(destination, symbolTickerDto);
+	}
+}

--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/subhandle/TopVolumeHandler.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/subhandle/TopVolumeHandler.java
@@ -1,0 +1,27 @@
+package com.zunza.buythedip.infrastructure.redis.subhandle;
+
+import java.util.List;
+
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class TopVolumeHandler implements RedisMessageHandler {
+
+	private final ObjectMapper objectMapper;
+	private final SimpMessageSendingOperations messagingTemplate;
+
+	private static final String TOP_N_VOLUME_DESTINATION = "/topic/crypto/volume/top";
+
+	@Override
+	public void handle(String message) throws JsonProcessingException {
+		List list = objectMapper.readValue(message, List.class);
+		messagingTemplate.convertAndSend(TOP_N_VOLUME_DESTINATION, list);
+	}
+}

--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/subhandle/TopVolumePriceHandler.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/subhandle/TopVolumePriceHandler.java
@@ -1,0 +1,26 @@
+package com.zunza.buythedip.infrastructure.redis.subhandle;
+
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zunza.buythedip.cryptocurrency.dto.RealtimePriceDto;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class TopVolumePriceHandler implements RedisMessageHandler {
+
+	private final ObjectMapper objectMapper;
+	private final SimpMessageSendingOperations messagingTemplate;
+
+	private static final String TOP_N_PRICE_DESTINATION = "/topic/crypto/price/top";
+
+	@Override
+	public void handle(String message) throws JsonProcessingException {
+		RealtimePriceDto realtimePriceDto = objectMapper.readValue(message, RealtimePriceDto.class);
+		messagingTemplate.convertAndSend(TOP_N_PRICE_DESTINATION, realtimePriceDto);
+	}
+}


### PR DESCRIPTION
기존:
- 기존 RedisMessageSubscriber는 새로운 메시지 채널이 추가될 때마다 switch 구문을 계속해서 수정해야 하는 구조
- 각 메시지를 처리하는 로직이 한 곳에 집중되어 가독성과 유지보수성이 떨어짐

개선: 
1. RedisMessageHandler 인터페이스 도입
- 모든 메시지 핸들러가 구현해야 하는 공통 handle(String message) 메서드를 정의하는 인터페이스를 생성

2. 각 채널별 Handler 구현체 생성
- 기존에 RedisMessageSubscriber에 있던 각 채널의 처리 로직을 ChatHandler, SymbolTickerHandler, TopVolumeHandler 등 역할에 맞는 별도의 클래스로 분리

3. RedisMessageSubscriber를 메시지 라우터로 전환
- RedisMessageSubscriber는 이제 생성 시점에 모든 RedisMessageHandler 구현체를 주입받아, 채널 이름을 키(Key)로, 핸들러 구현체를 값(Value)으로 하는 Map을 구성
- 메시지 수신 시, Map에서 채널 이름에 맞는 핸들러를 찾아 handle() 메서드를 호출하는 라우팅 역할만 수행