### PR TITLE
feat: 웹소켓 세션 구독 관리 구현

### DIFF
--- a/src/main/java/com/zunza/buythedip/config/StompSessionEventListener.java
+++ b/src/main/java/com/zunza/buythedip/config/StompSessionEventListener.java
@@ -1,0 +1,46 @@
+package com.zunza.buythedip.config;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
+
+import com.zunza.buythedip.infrastructure.redis.RedisSubscriptionManager;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class StompSessionEventListener {
+
+	private final RedisSubscriptionManager redisSubscriptionManager;
+
+	@EventListener
+	public void handleSessionSubscribe(SessionSubscribeEvent event) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+		String sessionId = accessor.getSessionId();
+		String subscriptionId = accessor.getSubscriptionId();
+		String destination = accessor.getDestination();
+
+		redisSubscriptionManager.handleSubscribe(sessionId, subscriptionId, destination);
+	}
+
+	@EventListener
+	public void handleSessionUnSubscribe(SessionUnsubscribeEvent event) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+		String sessionId = accessor.getSessionId();
+		String subscriptionId = accessor.getSubscriptionId();
+
+		redisSubscriptionManager.handleUnSubscribe(sessionId, subscriptionId);
+	}
+
+	@EventListener
+	public void handleDisConnect(SessionDisconnectEvent event) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+		String sessionId = accessor.getSessionId();
+
+		redisSubscriptionManager.handleDisconnect(sessionId);
+	}
+}

--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/RedisSubscriptionManager.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/RedisSubscriptionManager.java
@@ -1,0 +1,93 @@
+package com.zunza.buythedip.infrastructure.redis;
+
+import java.util.Set;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisSubscriptionManager {
+
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	private static final String SUBSCRIBER_COUNT_KEY_PREFIX = "subscribers:count:";
+	private static final String SESSION_SUBSCRIPTIONS_KEY_PREFIX = "session:subs:";
+	private static final String SUBSCRIPTION_DESTINATION_KEY_PREFIX = "sub:dest:";
+
+	public void handleSubscribe(String sessionId, String subscriptionId, String destination) {
+		if (sessionId == null || subscriptionId == null || destination == null) {
+			return;
+		}
+
+		String countKey = getCountKey(destination);
+		Long subscriberCount = redisTemplate.opsForValue().increment(countKey);
+		log.info("Subscribed to {}. Current subscribers: {}", destination, subscriberCount);
+
+		String sessionKey = getSessionKey(sessionId);
+		redisTemplate.opsForSet().add(sessionKey, destination);
+
+		String subDestinationKey = getSubDestinationKey(sessionId, subscriptionId);
+		redisTemplate.opsForValue().set(subDestinationKey, destination);
+	}
+
+	public void handleUnSubscribe(String sessionId, String subscriptionId) {
+		if (sessionId == null || subscriptionId == null) {
+			return;
+		}
+
+		String subDestinationKey = getSubDestinationKey(sessionId, subscriptionId);
+		String destination = redisTemplate.opsForValue().get(subDestinationKey).toString();
+
+		if (destination == null) {
+			return;
+		}
+
+		String countKey = getCountKey(destination);
+		Long subscriberCount = redisTemplate.opsForValue().decrement(countKey);
+		log.info("Unsubscribed from {}. Current subscribers: {}", destination, subscriberCount);
+
+		String sessionKey = getSessionKey(sessionId);
+		redisTemplate.opsForSet().remove(sessionKey, destination);
+		redisTemplate.delete(subDestinationKey);
+	}
+
+	public void handleDisconnect(String sessionId) {
+		if (sessionId == null) {
+			return;
+		}
+
+		String sessionKey = getSessionKey(sessionId);
+		Set<Object> destinations = redisTemplate.opsForSet().members(sessionKey);
+
+		if (destinations == null || destinations.isEmpty()) {
+			return;
+		}
+
+		destinations.forEach(destination -> {
+			String destinationStr = String.valueOf(destination);
+			String countKey = getCountKey(destinationStr);
+			Long subscriberCount = redisTemplate.opsForValue().decrement(countKey);
+			log.info("[Disconnected] Unsubscribed from {}. Current subscribers: {}", destination, subscriberCount);
+		});
+
+		redisTemplate.delete(sessionKey);
+		log.info("Cleaned up subscriptions for disconnected session: {}", sessionId);
+	}
+
+	private String getCountKey(String destination) {
+		return SUBSCRIBER_COUNT_KEY_PREFIX + destination;
+	}
+
+	private String getSessionKey(String sessionId) {
+		return SESSION_SUBSCRIPTIONS_KEY_PREFIX + sessionId;
+	}
+
+	private String getSubDestinationKey(String sessionId, String subscriptionId) {
+		return SUBSCRIPTION_DESTINATION_KEY_PREFIX + sessionId + ":" + subscriptionId;
+	}
+}


### PR DESCRIPTION
사용자가 암호화폐 상세 페이지에 접속했을 때 어떤 암호화폐 시세 토픽을 실시간으로 구독하고 있는지 서버가 동적으로 파악하고, 구독자가 있는 토픽에만 데이터를 전송하는 시스템 구축

1. STOMP 세션 이벤트 리스닝 (StompSessionEventListener)
- Spring의 ApplicationEvent를 활용하여, 클라이언트의 STOMP 구독(SUBSCRIBE), 구독 취소(UNSUBSCRIBE), 연결 종료(DISCONNECT) 이벤트를 실시간으로 감지하는 리스너를 구현

2. Redis를 이용한 구독 정보 관리 (RedisSubscriptionManager)
- 모든 구독/구독해지 이벤트 정보를 Redis에 저장
- subscribers:count:{destination}이라는 키를 사용하여, 각 토픽별 현재 구독자 수를 실시간으로 카운팅(INCR/DECR)
- 서버가 스케일아웃 되더라도, 모든 인스턴스가 Redis를 통해 특정 토픽의 현재 구독자 수를 공유
