### PR TITLE
test: 뉴스 번역 컨슈머의 예외처리 및 재시도 처리에 대한 단위 테스트 추가

### DIFF
--- a/src/test/java/com/zunza/buythedip/news/service/NewsTranslationServiceTest.java
+++ b/src/test/java/com/zunza/buythedip/news/service/NewsTranslationServiceTest.java
@@ -3,6 +3,7 @@ package com.zunza.buythedip.news.service;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.io.IOException;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -11,17 +12,16 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageBuilder;
 
+import com.google.genai.errors.ApiException;
+import com.rabbitmq.client.Channel;
 import com.zunza.buythedip.constant.RabbitMQConstants;
-import com.zunza.buythedip.infrastructure.gemini.GeminiClient;
-import com.zunza.buythedip.infrastructure.gemini.dto.CandidateDto;
-import com.zunza.buythedip.infrastructure.gemini.dto.ContentDto;
-import com.zunza.buythedip.infrastructure.gemini.dto.GeminiResponseDto;
-import com.zunza.buythedip.infrastructure.gemini.dto.PartDto;
+import com.zunza.buythedip.infrastructure.gemini.service.GenAiService;
 import com.zunza.buythedip.infrastructure.messaging.RabbitMQService;
 import com.zunza.buythedip.news.dto.NewsDto;
 
-import reactor.core.publisher.Mono;
 
 @ExtendWith(MockitoExtension.class)
 class NewsTranslationServiceTest {
@@ -30,46 +30,136 @@ class NewsTranslationServiceTest {
 	private RabbitMQService rabbitMQService;
 
 	@Mock
-	private GeminiClient geminiClient;
+	private GenAiService genAiService;
+
+	@Mock
+	private Channel channel;
 
 	@InjectMocks
 	private NewsTranslationService newsTranslationService;
 
 	@Test
-	void 뉴스_리스트가_들어오면_헤드라인과_요약을_번역하고_큐에_전송한다() {
+	void 뉴스_리스트가_들어오면_헤드라인과_요약을_번역하고_큐에_전송한다() throws IOException {
 		// given
 		NewsDto newsDto = NewsDto.builder()
 			.headline("Original Headline")
 			.summary("Original Summary")
 			.build();
-
-		String text = "headline: 번역된 헤드라인\n\nsummary: 번역된 요약";
-
-		PartDto partDto = PartDto.from(text);
-		ContentDto contentDto = ContentDto.from(List.of(partDto));
-		CandidateDto candidateDto = CandidateDto.from(contentDto);
-		GeminiResponseDto geminiResponseDto = GeminiResponseDto.from(List.of(candidateDto));
-
-		when(geminiClient.translateHeadlineAndSummary(newsDto.getHeadline(), newsDto.getSummary()))
-			.thenReturn(Mono.just(geminiResponseDto));
-
 		List<NewsDto> newsDtoList = List.of(newsDto);
 
+		Message message = MessageBuilder.withBody(new byte[0])
+			.setHeader("x-retry-count", null)
+			.build();
+
+		String response = "headline: 번역된 헤드라인\n\nsummary: 번역된 요약";
+
+		when(genAiService.generate(anyString()))
+			.thenReturn(response);
+
 		// when
-		newsTranslationService.translateNews(newsDtoList);
+		newsTranslationService.translateNews(newsDtoList, message, channel, 123L);
 
 		// then
 		ArgumentCaptor<List<NewsDto>> captor = ArgumentCaptor.forClass(List.class);
-		verify(rabbitMQService).publishMessage(
+		verify(channel).basicAck(123L, false);
+		verify(rabbitMQService, only()).publishMessage(
 			eq(RabbitMQConstants.PUBLIC_EXCHANGE),
 			eq(RabbitMQConstants.NEWS_STORAGE_ROUTING_KEY),
 			captor.capture()
 		);
 
-		List<NewsDto> translatedNewsDtoList = captor.getValue();
-		NewsDto translatedNewsDto = translatedNewsDtoList.get(0);
+		List<NewsDto> value = captor.getValue();
+		assertEquals("번역된 헤드라인", value.get(0).getHeadline());
+		assertEquals("번역된 요약", value.get(0).getSummary());
+	}
 
-		assertEquals(translatedNewsDto.getHeadline(), "번역된 헤드라인");
-		assertEquals(translatedNewsDto.getSummary(), "번역된 요약");
+	@Test
+	void API_할당량_한도를_초과하면_큐에_넣지않고_ack로_메시지를_완전_소비처리한다() throws IOException {
+		// given
+		NewsDto newsDto = NewsDto.builder()
+			.headline("Original Headline")
+			.summary("Original Summary")
+			.build();
+		List<NewsDto> newsDtoList = List.of(newsDto);
+
+		Message message = MessageBuilder.withBody(new byte[0])
+			.setHeader("x-retry-count", 0)
+			.build();
+
+		ApiException mockApiException = mock(ApiException.class);
+		when(mockApiException.status())
+			.thenReturn("RESOURCE_EXHAUSTED");
+
+		when(genAiService.generate(anyString()))
+			.thenThrow(mockApiException);
+
+		//when
+		newsTranslationService.translateNews(newsDtoList, message, channel, 123L);
+
+		//then
+		verify(channel, only()).basicAck(123L, false);
+		verify(rabbitMQService, never()).publishMessage(
+			anyString(),
+			anyString(),
+			any()
+		);
+	}
+
+	@Test
+	void 일반_예외_발생_시_수동으로_재시도_처리를_한다() throws IOException {
+		// given
+		NewsDto newsDto = NewsDto.builder()
+			.headline("Original Headline")
+			.summary("Original Summary")
+			.build();
+		List<NewsDto> newsDtoList = List.of(newsDto);
+
+		Message message = MessageBuilder.withBody(new byte[0])
+			.setHeader("x-retry-count", 0)
+			.build();
+
+		when(genAiService.generate(anyString()))
+			.thenThrow(new RuntimeException());
+
+		//when
+		newsTranslationService.translateNews(newsDtoList, message, channel, 123L);
+
+		//then
+		verify(rabbitMQService, only()).publishMessage(
+			eq(RabbitMQConstants.PUBLIC_EXCHANGE),
+			eq(RabbitMQConstants.NEWS_TRANSLATION_ROUTING_KEY + ".retry"),
+			eq(message)
+		);
+		verify(channel, only()).basicAck(123L, false);
+
+		assertEquals(1, message.getMessageProperties().getHeaders().get("x-retry-count"));
+	}
+
+	@Test
+	void 재시도_횟수를_초과하면_ack로_메시지지를_완전_소비해버린다() throws IOException {
+		// given
+		NewsDto newsDto = NewsDto.builder()
+			.headline("Original Headline")
+			.summary("Original Summary")
+			.build();
+		List<NewsDto> newsDtoList = List.of(newsDto);
+
+		Message message = MessageBuilder.withBody(new byte[0])
+			.setHeader("x-retry-count", 3)
+			.build();
+
+		when(genAiService.generate(anyString()))
+			.thenThrow(new RuntimeException());
+
+		//when
+		newsTranslationService.translateNews(newsDtoList, message, channel, 123L);
+
+		//then
+		verify(rabbitMQService, never()).publishMessage(
+			anyString(),
+			anyString(),
+			any()
+		);
+		verify(channel, only()).basicAck(123L, false);
 	}
 }


### PR DESCRIPTION
1. API 할당량 한도 초과 시
- GenAiService가 API 할당량 초과 예외(ApiException with "RESOURCE_EXHAUSTED")를 발생시키는 상황을 가정
- 메시지를 재시도 큐로 보내지 않고 (never() publishMessage), 즉시 channel.basicAck()를 호출하여 메시지를 완전히 소비 처리하는지 확인

2. 일반 예외 발생 시
- 네트워크 오류 등 일시적인 RuntimeException이 발생하는 상황을 가정
- 메시지 헤더의 x-retry-count가 1 증가하는지 확인
- 수정된 메시지가 재시도 큐로 정확히 발행되는지 확인
- 원본 메시지는 channel.basicAck()로 정상적으로 소비 처리되는지 확인

3. 최대 재시도 횟수 초과 시
- 메시지 헤더의 x-retry-count가 이미 최대치(3)에 도달한 상태에서 또다시 RuntimeException이 발생하는 상황을 가정
- 더 이상 재시도 큐로 메시지를 보내지 않고 (never() publishMessage), channel.basicAck()를 호출하여 메시지를 최종적으로 소비 처리하는지 확인