### PR TITLE
refactor: 추상 클래스를 도입하여 바이낸스 WebSocket 수신 로직 중복 제거

### DIFF
--- a/src/main/java/com/zunza/buythedip/cryptocurrency/service/broadcast/AbstractBinanceStreamReceiver.java
+++ b/src/main/java/com/zunza/buythedip/cryptocurrency/service/broadcast/AbstractBinanceStreamReceiver.java
@@ -1,0 +1,34 @@
+package com.zunza.buythedip.cryptocurrency.service.broadcast;
+
+import org.springframework.web.socket.client.WebSocketClient;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public abstract class AbstractBinanceStreamReceiver extends TextWebSocketHandler {
+
+	protected final WebSocketClient webSocketClient;
+	protected final ObjectMapper objectMapper;
+
+	protected static final String URL = "wss://data-stream.binance.vision/stream";
+
+	protected AbstractBinanceStreamReceiver(WebSocketClient webSocketClient, ObjectMapper objectMapper) {
+		this.webSocketClient = webSocketClient;
+		this.objectMapper = objectMapper;
+	}
+
+	@PostConstruct
+	public void connect() {
+		try {
+			log.info("[{}] Connecting to Binance WebSocket", getClass().getSimpleName());
+			webSocketClient.execute(this, URL).get();
+			log.info("[{}] Connected successfully", getClass().getSimpleName());
+		} catch (Exception e) {
+			log.error("[{}] Connection failed: {}", getClass().getSimpleName(), e.getMessage());
+		}
+	}
+}

--- a/src/main/java/com/zunza/buythedip/cryptocurrency/service/broadcast/KlineStreamReceiver.java
+++ b/src/main/java/com/zunza/buythedip/cryptocurrency/service/broadcast/KlineStreamReceiver.java
@@ -1,0 +1,37 @@
+package com.zunza.buythedip.cryptocurrency.service.broadcast;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.client.WebSocketClient;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+public class KlineStreamReceiver extends AbstractBinanceStreamReceiver {
+
+	public KlineStreamReceiver(
+		WebSocketClient webSocketClient,
+		ObjectMapper objectMapper
+	) {
+		super(webSocketClient, objectMapper);
+	}
+
+	@Override
+	public void connect() {
+		super.connect();
+	}
+
+	@Override
+	public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+		super.afterConnectionEstablished(session);
+	}
+
+	@Override
+	protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+		super.handleTextMessage(session, message);
+	}
+}

--- a/src/main/java/com/zunza/buythedip/cryptocurrency/service/broadcast/TradeStreamReceiver.java
+++ b/src/main/java/com/zunza/buythedip/cryptocurrency/service/broadcast/TradeStreamReceiver.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.client.WebSocketClient;
-import org.springframework.web.socket.handler.TextWebSocketHandler;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -15,34 +14,32 @@ import com.zunza.buythedip.cryptocurrency.entity.Cryptocurrency;
 import com.zunza.buythedip.cryptocurrency.handler.BinanceMessageRouter;
 import com.zunza.buythedip.cryptocurrency.repository.CryptocurrencyRepository;
 
-import jakarta.annotation.PostConstruct;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
-public class TradeStreamReceiver extends TextWebSocketHandler {
+public class TradeStreamReceiver extends AbstractBinanceStreamReceiver {
 
 	private final CryptocurrencyRepository cryptoCurrencyRepository;
 	private final BinanceMessageRouter binanceMessageRouter;
-	private final WebSocketClient webSocketClient;
-	private final ObjectMapper objectMapper;
 
-	public static final String URL = "wss://data-stream.binance.vision/stream";
 	public static final String STREAM_SUFFIX = "usdt@trade";
 
-	@PostConstruct
+	public TradeStreamReceiver(
+		WebSocketClient webSocketClient,
+		ObjectMapper objectMapper,
+		CryptocurrencyRepository cryptoCurrencyRepository,
+		BinanceMessageRouter binanceMessageRouter
+	) {
+		super(webSocketClient, objectMapper);
+		this.cryptoCurrencyRepository = cryptoCurrencyRepository;
+		this.binanceMessageRouter = binanceMessageRouter;
+	}
+
+	@Override
 	public void connect() {
-		try {
-			log.info("start connecting...");
-			webSocketClient.execute(this, URL).get();
-			log.info("Binance WebSocket Streams Connected");
-		} catch (Exception e) {
-			log.error("Binance WebSocket Streams Connect failed");
-			log.error(e.getMessage());
-		}
+		super.connect();
 	}
 
 	@Override


### PR DESCRIPTION
1. AbstractBinanceStreamReceiver 추상 클래스 도입
 - 모든 바이낸스 스트림 수신 클래스가 공통적으로 가져야 할 로직과 상태를 관리하는 추상 클래스를 생성
- 공통 로직:
  - @PostConstruct를 이용한 WebSocket 자동 연결 (connect())
  - 연결 실패 시 에러 로깅
  - WebSocketClient, ObjectMapper 등 공통 의존성 관리

2. 각 스트림별 구체 클래스
- TradeStreamReceiver:
  - AbstractBinanceStreamReceiver를 상속
  - afterConnectionEstablished()를 오버라이드하여, Trade 스트림에 특화된 구독 메시지(SUBSCRIBE)를 전송
  - handleTextMessage()를 오버라이드하여, 수신된 Trade 데이터를 파싱하고 BinanceMessageRouter로 전달
- KlineStreamReceiver:
  - 마찬가지로 추상 클래스를 상속받아, 향후 Kline 스트림에 필요한 구독 및 메시지 처리 로직을 이 클래스 내부에 구현할 예정