### PR TITLE
feat: 실시간 구독자 수 기반의 동적 바이낸스 Kline 구독/해제 기능 구현

### DIFF
--- a/src/main/java/com/zunza/buythedip/cryptocurrency/dto/binance/CandlestickData.java
+++ b/src/main/java/com/zunza/buythedip/cryptocurrency/dto/binance/CandlestickData.java
@@ -1,0 +1,22 @@
+package com.zunza.buythedip.cryptocurrency.dto.binance;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CandlestickData {
+	private long time;
+	private double open;
+	private double high;
+	private double low;
+	private double close;
+
+	@Builder
+	public CandlestickData(long time, double open, double high, double low, double close) {
+		this.time = time;
+		this.open = open;
+		this.high = high;
+		this.low = low;
+		this.close = close;
+	}
+}

--- a/src/main/java/com/zunza/buythedip/cryptocurrency/dto/binance/KlineDto.java
+++ b/src/main/java/com/zunza/buythedip/cryptocurrency/dto/binance/KlineDto.java
@@ -1,0 +1,93 @@
+package com.zunza.buythedip.cryptocurrency.dto.binance;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class KlineDto {
+	private String symbol;
+	private String interval;
+	private CandlestickData candlestick;
+	private VolumeData volumeData;
+
+	public static final String COLOR_BULLISH = "rgba(0, 150, 136, 0.8)";
+	public static final String COLOR_BEARISH = "rgba(0, 150, 136, 0.8)";
+
+	@Builder
+	public KlineDto(String symbol, String interval, CandlestickData candlestick, VolumeData volumeData) {
+		this.symbol = symbol;
+		this.interval = interval;
+		this.candlestick = candlestick;
+		this.volumeData = volumeData;
+	}
+
+	public static KlineDto createKlineDtoForUpdate(JsonNode jsonNode) {
+		String symbol = jsonNode.get("s").asText();
+		String baseSymbol = symbol.replace("USDT", "");
+		JsonNode klineNode = jsonNode.get("k");
+		String interval = klineNode.get("i").asText();
+
+		long time = klineNode.get("t").asLong() / 1000;
+		double open = klineNode.get("o").asDouble();
+		double high = klineNode.get("h").asDouble();
+		double low = klineNode.get("l").asDouble();
+		double close = klineNode.get("c").asDouble();
+		double volume = klineNode.get("v").asDouble();
+		String color = (close >= open) ? COLOR_BULLISH : COLOR_BEARISH;
+
+		CandlestickData candlestickData = CandlestickData.builder()
+			.time(time)
+			.open(open)
+			.high(high)
+			.low(low)
+			.close(close)
+			.build();
+
+		VolumeData volumeData = VolumeData.builder()
+			.time(time)
+			.value(volume)
+			.color(color)
+			.build();
+
+		return KlineDto.builder()
+			.symbol(baseSymbol)
+			.interval(interval)
+			.candlestick(candlestickData)
+			.volumeData(volumeData)
+			.build();
+	}
+
+	public static KlineDto createKlineDtoForInit(List<Object> list) {
+		long time = ((Number)list.get(0)).longValue() / 1000;
+		double open = Double.parseDouble(String.valueOf(list.get(1)));
+		double high = Double.parseDouble(String.valueOf(list.get(2)));
+		double low = Double.parseDouble(String.valueOf(list.get(3)));
+		double close = Double.parseDouble(String.valueOf(list.get(4)));
+		double volume = Double.parseDouble(String.valueOf(list.get(5)));
+		String color = (open >= close) ? COLOR_BULLISH : COLOR_BEARISH;
+
+		CandlestickData candle = CandlestickData.builder()
+			.time(time)
+			.open(open)
+			.high(high)
+			.low(low)
+			.close(close)
+			.build();
+
+		VolumeData volumeData = VolumeData.builder()
+			.time(time)
+			.value(volume)
+			.color(color)
+			.build();
+
+		return KlineDto.builder()
+			.candlestick(candle)
+			.volumeData(volumeData)
+			.build();
+	}
+
+}

--- a/src/main/java/com/zunza/buythedip/cryptocurrency/dto/binance/VolumeData.java
+++ b/src/main/java/com/zunza/buythedip/cryptocurrency/dto/binance/VolumeData.java
@@ -1,0 +1,18 @@
+package com.zunza.buythedip.cryptocurrency.dto.binance;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class VolumeData {
+	private long time;
+	private double value;
+	private String color;
+
+	@Builder
+	public VolumeData(long time, double value, String color) {
+		this.time = time;
+		this.value = value;
+		this.color = color;
+	}
+}

--- a/src/main/java/com/zunza/buythedip/cryptocurrency/service/AbstractBinanceStreamReceiver.java
+++ b/src/main/java/com/zunza/buythedip/cryptocurrency/service/AbstractBinanceStreamReceiver.java
@@ -13,19 +13,25 @@ public abstract class AbstractBinanceStreamReceiver extends TextWebSocketHandler
 
 	protected final WebSocketClient webSocketClient;
 	protected final ObjectMapper objectMapper;
+	protected String url;
 
 	protected static final String URL = "wss://data-stream.binance.vision/stream";
 
-	protected AbstractBinanceStreamReceiver(WebSocketClient webSocketClient, ObjectMapper objectMapper) {
+	protected AbstractBinanceStreamReceiver(
+		WebSocketClient webSocketClient,
+		ObjectMapper objectMapper,
+		String url
+	) {
 		this.webSocketClient = webSocketClient;
 		this.objectMapper = objectMapper;
+		this.url = url;
 	}
 
 	@PostConstruct
 	public void connect() {
 		try {
 			log.info("[{}] Connecting to Binance WebSocket", getClass().getSimpleName());
-			webSocketClient.execute(this, URL).get();
+			webSocketClient.execute(this, url).get();
 			log.info("[{}] Connected successfully", getClass().getSimpleName());
 		} catch (Exception e) {
 			log.error("[{}] Connection failed: {}", getClass().getSimpleName(), e.getMessage());

--- a/src/main/java/com/zunza/buythedip/cryptocurrency/service/kline/KlineStreamManager.java
+++ b/src/main/java/com/zunza/buythedip/cryptocurrency/service/kline/KlineStreamManager.java
@@ -1,0 +1,53 @@
+package com.zunza.buythedip.cryptocurrency.service.kline;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zunza.buythedip.cryptocurrency.dto.SubDto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Getter
+@Service
+@RequiredArgsConstructor
+public class KlineStreamManager {
+
+	private final ObjectMapper objectMapper;
+	private WebSocketSession session;
+
+	private static final String SYMBOL_SUFFIX = "usdt";
+	private static final String STREAM_SUFFIX = "@kline_";
+
+	public void registerKlineSession(WebSocketSession session) {
+		this.session = session;
+	}
+
+	public void subKlineForSymbol(String symbol, String interval) throws IOException {
+		String param = symbol + SYMBOL_SUFFIX + STREAM_SUFFIX + interval;
+		sendMessage("SUBSCRIBE", param);
+	}
+
+	public void unSubKlineForSymbol(String symbol, String interval) throws IOException {
+		String param = symbol + SYMBOL_SUFFIX + STREAM_SUFFIX + interval;
+		sendMessage("UNSUBSCRIBE", param);
+	}
+
+	private void sendMessage(String method, String param) throws IOException {
+		SubDto subDto = new SubDto(method, List.of(param), session.getId());
+
+		String req = objectMapper.writeValueAsString(subDto);
+		try {
+			session.sendMessage(new TextMessage(req));
+		} catch (Exception e) {
+			log.info("Error Message: {}", e.getMessage());
+		}
+	}
+}

--- a/src/main/java/com/zunza/buythedip/cryptocurrency/service/kline/KlineStreamReceiver.java
+++ b/src/main/java/com/zunza/buythedip/cryptocurrency/service/kline/KlineStreamReceiver.java
@@ -5,8 +5,12 @@ import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.client.WebSocketClient;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zunza.buythedip.constant.ChannelNames;
+import com.zunza.buythedip.cryptocurrency.dto.binance.KlineDto;
 import com.zunza.buythedip.cryptocurrency.service.AbstractBinanceStreamReceiver;
+import com.zunza.buythedip.infrastructure.redis.RedisMessagePublisher;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -14,11 +18,22 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 public class KlineStreamReceiver extends AbstractBinanceStreamReceiver {
 
+	private final RedisMessagePublisher redisMessagePublisher;
+	private final KlineStreamManager klineStreamManager;
+	private final ObjectMapper objectMapper;
+
+	public static final String URL = "wss://data-stream.binance.vision/ws";
+
 	public KlineStreamReceiver(
+		RedisMessagePublisher redisMessagePublisher,
+		KlineStreamManager klineStreamManager,
 		WebSocketClient webSocketClient,
 		ObjectMapper objectMapper
 	) {
-		super(webSocketClient, objectMapper);
+		super(webSocketClient, objectMapper, URL);
+		this.klineStreamManager = klineStreamManager;
+		this.objectMapper = objectMapper;
+		this.redisMessagePublisher = redisMessagePublisher;
 	}
 
 	@Override
@@ -28,11 +43,18 @@ public class KlineStreamReceiver extends AbstractBinanceStreamReceiver {
 
 	@Override
 	public void afterConnectionEstablished(WebSocketSession session) throws Exception {
-		super.afterConnectionEstablished(session);
+		klineStreamManager.registerKlineSession(session);
 	}
 
 	@Override
 	protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
-		super.handleTextMessage(session, message);
+		JsonNode jsonNode = objectMapper.readTree(message.getPayload());
+
+		if (jsonNode.get("s") == null) {
+			return;
+		}
+
+		KlineDto klineDto = KlineDto.createKlineDtoForUpdate(jsonNode);
+		redisMessagePublisher.publishMessage(ChannelNames.SYMBOL_KLINE_TOPIC, klineDto);
 	}
 }

--- a/src/main/java/com/zunza/buythedip/cryptocurrency/service/trade/TradeStreamReceiver.java
+++ b/src/main/java/com/zunza/buythedip/cryptocurrency/service/trade/TradeStreamReceiver.java
@@ -9,13 +9,13 @@ import org.springframework.web.socket.client.WebSocketClient;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zunza.buythedip.cryptocurrency.dto.SubDto;
 import com.zunza.buythedip.cryptocurrency.dto.binance.StreamDto;
 import com.zunza.buythedip.cryptocurrency.entity.Cryptocurrency;
 import com.zunza.buythedip.cryptocurrency.handler.BinanceMessageRouter;
 import com.zunza.buythedip.cryptocurrency.repository.CryptocurrencyRepository;
 import com.zunza.buythedip.cryptocurrency.service.AbstractBinanceStreamReceiver;
 
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -25,6 +25,7 @@ public class TradeStreamReceiver extends AbstractBinanceStreamReceiver {
 	private final CryptocurrencyRepository cryptoCurrencyRepository;
 	private final BinanceMessageRouter binanceMessageRouter;
 
+	public static final String URL = "wss://data-stream.binance.vision/stream";
 	public static final String STREAM_SUFFIX = "usdt@trade";
 
 	public TradeStreamReceiver(
@@ -33,7 +34,7 @@ public class TradeStreamReceiver extends AbstractBinanceStreamReceiver {
 		CryptocurrencyRepository cryptoCurrencyRepository,
 		BinanceMessageRouter binanceMessageRouter
 	) {
-		super(webSocketClient, objectMapper);
+		super(webSocketClient, objectMapper, URL);
 		this.cryptoCurrencyRepository = cryptoCurrencyRepository;
 		this.binanceMessageRouter = binanceMessageRouter;
 	}
@@ -50,7 +51,8 @@ public class TradeStreamReceiver extends AbstractBinanceStreamReceiver {
 			.map(crypto -> crypto.getSymbol().toLowerCase() + STREAM_SUFFIX)
 			.toList();
 
-		SubDto subscribe = new SubDto("SUBSCRIBE", symbols);
+
+		SubDto subscribe = new SubDto("SUBSCRIBE", symbols, session.getId());
 		String value = objectMapper.writeValueAsString(subscribe);
 
 		session.sendMessage(new TextMessage(value));
@@ -66,19 +68,5 @@ public class TradeStreamReceiver extends AbstractBinanceStreamReceiver {
 		}
 
 		binanceMessageRouter.route(streamDto.getTradeDto());
-	}
-
-	@Getter
-	public static class SubDto {
-		private String method;
-		private List<String> params;
-
-		public SubDto() {
-		}
-
-		public SubDto(String method, List<String> params) {
-			this.method = method;
-			this.params = params;
-		}
 	}
 }

--- a/src/main/java/com/zunza/buythedip/session/StompSessionEventListener.java
+++ b/src/main/java/com/zunza/buythedip/session/StompSessionEventListener.java
@@ -1,0 +1,79 @@
+package com.zunza.buythedip.session;
+
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
+
+import com.zunza.buythedip.session.manage.AbstractSubscriptionManager;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class StompSessionEventListener {
+
+	private final AbstractSubscriptionManager tradeSubscriptionManger;
+	private final AbstractSubscriptionManager klineSubscriptionManger;
+	private final AbstractSubscriptionManager chatSubscriptionManager;
+
+	public StompSessionEventListener(
+		@Qualifier("tradeSubscriptionManager")AbstractSubscriptionManager tradeSubscriptionManger,
+		@Qualifier("klineSubscriptionManager")AbstractSubscriptionManager klineSubscriptionManger,
+		@Qualifier("chatSubscriptionManager")AbstractSubscriptionManager chatSubscriptionManger
+	) {
+		this.tradeSubscriptionManger = tradeSubscriptionManger;
+		this.klineSubscriptionManger = klineSubscriptionManger;
+		this.chatSubscriptionManager = chatSubscriptionManger;
+	}
+
+	@EventListener
+	public void handleSessionSubscribe(SessionSubscribeEvent event) throws IOException {
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+
+		String sessionId = accessor.getSessionId();
+		String subscriptionId = accessor.getSubscriptionId();
+		String destination = accessor.getDestination();
+
+		handleSubscribe(sessionId, subscriptionId, destination);
+	}
+
+	@EventListener
+	public void handleSessionUnSubscribe(SessionUnsubscribeEvent event) throws IOException {
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+		Object endpointPath = accessor.getSessionAttributes().get("endpointPath");
+		log.info("[UnSubscription] | [{}]", String.valueOf(endpointPath));
+		log.info("[UnSubscription] | [{}]", String.valueOf(accessor.getDestination()));
+
+		String sessionId = accessor.getSessionId();
+		String subscriptionId = accessor.getSubscriptionId();
+
+		tradeSubscriptionManger.handleUnSubscribe(sessionId, subscriptionId);
+		klineSubscriptionManger.handleUnSubscribe(sessionId, subscriptionId);
+	}
+
+	@EventListener
+	public void handleDisConnect(SessionDisconnectEvent event) throws IOException {
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+		Object endpointPath = accessor.getSessionAttributes().get("endpointPath");
+		log.info("[DisConnect] | [{}]", String.valueOf(endpointPath));
+		log.info("[DisConnect] | [{}]", String.valueOf(accessor.getDestination()));
+
+		String sessionId = accessor.getSessionId();
+
+		chatSubscriptionManager.handleDisconnect(sessionId);
+		tradeSubscriptionManger.handleDisconnect(sessionId);
+		klineSubscriptionManger.handleDisconnect(sessionId);
+	}
+
+	private void handleSubscribe(String sessionId, String subscriptionId, String destination) throws IOException {
+		klineSubscriptionManger.handleSubscribe(sessionId, subscriptionId, destination);
+		tradeSubscriptionManger.handleSubscribe(sessionId, subscriptionId, destination);
+		chatSubscriptionManager.handleSubscribe(sessionId, subscriptionId, destination);
+	}
+}

--- a/src/main/java/com/zunza/buythedip/session/manage/AbstractSubscriptionManager.java
+++ b/src/main/java/com/zunza/buythedip/session/manage/AbstractSubscriptionManager.java
@@ -1,0 +1,115 @@
+package com.zunza.buythedip.session.manage;
+
+import java.io.IOException;
+import java.util.Set;
+
+import org.springframework.data.redis.core.RedisTemplate;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public abstract class AbstractSubscriptionManager {
+
+	protected final RedisTemplate<String, Object> redisTemplate;
+
+	private static final String SUBSCRIBER_COUNT_KEY_PREFIX = "subscribers:count:";
+	private static final String SESSION_SUBSCRIPTIONS_KEY_PREFIX = "session:subs:";
+	private static final String SUBSCRIPTION_DESTINATION_KEY_PREFIX = "sub:dest:";
+
+	protected AbstractSubscriptionManager(RedisTemplate<String, Object> redisTemplate) {
+		this.redisTemplate = redisTemplate;
+	}
+
+	public final void handleSubscribe(String sessionId, String subscriptionId, String destination) throws IOException {
+		if (destination == null || !canHandle(destination)) {
+			return;
+		}
+
+		String countKey = getCountKey(destination);
+		Long subscriberCount = redisTemplate.opsForValue().increment(countKey);
+		log.info("Subscribed to {} | Current subscribers: {}", destination, subscriberCount);
+
+		String sessionKey = getSessionKey(sessionId);
+		redisTemplate.opsForSet().add(sessionKey, destination);
+
+		String subDestinationKey = getSubDestinationKey(sessionId, subscriptionId);
+		redisTemplate.opsForValue().set(subDestinationKey, destination);
+
+		if (subscriberCount != null && subscriberCount == 1) {
+			onFirstSubscriber(destination);
+		}
+	}
+
+	public void handleUnSubscribe(String sessionId, String subscriptionId) throws IOException {
+		String subDestinationKey = getSubDestinationKey(sessionId, subscriptionId);
+		String destination = String.valueOf(redisTemplate.opsForValue().get(subDestinationKey));
+
+		if (destination == null || !canHandle(destination)) {
+			return;
+		}
+
+		String countKey = getCountKey(destination);
+		Long subscriberCount = redisTemplate.opsForValue().decrement(countKey);
+		log.info("Unsubscribed from {}. Current subscribers: {}", destination, subscriberCount);
+
+		String sessionKey = getSessionKey(sessionId);
+		redisTemplate.opsForSet().remove(sessionKey, destination);
+		redisTemplate.delete(subDestinationKey);
+
+		if (subscriberCount != null && subscriberCount == 0) {
+			onLastSubscriber(destination);
+		}
+	}
+
+	protected void decrementSubscriberCounts(Set<String> destinations) throws IOException {
+		if (destinations == null || destinations.isEmpty()) return;
+
+		destinations.forEach(destination -> {
+			String countKey = getCountKey(destination);
+			Long subscriberCount = redisTemplate.opsForValue().decrement(countKey);
+			log.info("[Disconnected] Unsubscribed from {}. Current subscribers: {}", destination, subscriberCount);
+		});
+
+		for (String destination : destinations) {
+			String countKey = getCountKey(destination);
+			Integer count = (Integer)redisTemplate.opsForValue().get(countKey);
+			if (count != null && count == 0) {
+				onLastSubscriber(destination);
+			}
+		}
+	}
+
+	protected void cleanupAllSessionData(String sessionId) {
+		Set<String> subDestKeys = redisTemplate.keys(SUBSCRIPTION_DESTINATION_KEY_PREFIX + sessionId + ":*");
+		if (subDestKeys != null && !subDestKeys.isEmpty()) {
+			redisTemplate.delete(subDestKeys);
+		}
+
+		redisTemplate.delete(getSessionKey(sessionId));
+		log.info("Cleaned up all subscription metadata for session: {}", sessionId);
+	}
+
+	public abstract void handleDisconnect(String sessionId) throws IOException;
+
+	protected abstract void onFirstSubscriber(String destination) throws IOException;
+
+	protected abstract void onLastSubscriber(String destination) throws IOException;
+
+	protected abstract boolean canHandle(String destination);
+
+	protected Set<Object> getSubscribedDestinationsForSession(String sessionId) {
+		return redisTemplate.opsForSet().members(getSessionKey(sessionId));
+	}
+
+	private String getCountKey(String destination) {
+		return SUBSCRIBER_COUNT_KEY_PREFIX + destination;
+	}
+
+	private String getSessionKey(String sessionId) {
+		return SESSION_SUBSCRIPTIONS_KEY_PREFIX + sessionId;
+	}
+
+	private String getSubDestinationKey(String sessionId, String subscriptionId) {
+		return SUBSCRIPTION_DESTINATION_KEY_PREFIX + sessionId + ":" + subscriptionId;
+	}
+}

--- a/src/main/java/com/zunza/buythedip/session/manage/klineSubscriptionManager.java
+++ b/src/main/java/com/zunza/buythedip/session/manage/klineSubscriptionManager.java
@@ -1,0 +1,76 @@
+package com.zunza.buythedip.session.manage;
+
+import java.io.IOException;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import com.zunza.buythedip.cryptocurrency.service.kline.KlineStreamManager;
+import com.zunza.buythedip.infrastructure.redis.subhandle.Destination;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service("klineSubscriptionManager")
+public class klineSubscriptionManager extends AbstractSubscriptionManager {
+
+	private final KlineStreamManager klineStreamManager;
+
+	public klineSubscriptionManager(
+		RedisTemplate<String, Object> redisTemplate,
+		KlineStreamManager klineStreamManager
+	) {
+		super(redisTemplate);
+		this.klineStreamManager = klineStreamManager;
+	}
+
+	@Override
+	public void handleDisconnect(String sessionId) throws IOException {
+		Set<Object> destinations = getSubscribedDestinationsForSession(sessionId);
+		if (destinations == null || destinations.isEmpty()) {
+			return;
+		}
+
+		Set<String> klineDestinations = destinations.stream()
+			.filter(des -> des != null && des.toString().startsWith(Destination.SYMBOL_KLINE_DESTINATION_PREFIX.getDestination()))
+			.map(String::valueOf)
+			.collect(Collectors.toSet());
+
+		decrementSubscriberCounts(klineDestinations);
+		log.info("[Kline] Cleaned up kline subscriptions for disconnected session: {}", sessionId);
+
+		cleanupAllSessionData(sessionId);
+	}
+
+	@Override
+	protected void onFirstSubscriber(String destination) throws IOException {
+		SymbolInterval symbolInterval = extractSymbolAndInterval(destination);
+		klineStreamManager.subKlineForSymbol(symbolInterval.symbol, symbolInterval.interval);
+	}
+
+	@Override
+	protected void onLastSubscriber(String destination) throws IOException {
+		SymbolInterval symbolInterval = extractSymbolAndInterval(destination);
+		klineStreamManager.unSubKlineForSymbol(symbolInterval.symbol, symbolInterval.interval);
+	}
+
+	@Override
+	protected boolean canHandle(String destination) {
+		return destination != null && destination.startsWith(Destination.SYMBOL_KLINE_DESTINATION_PREFIX.getDestination());
+	}
+
+	private SymbolInterval extractSymbolAndInterval(String destination) {
+		String substring = destination.substring(Destination.SYMBOL_KLINE_DESTINATION_PREFIX.getDestination().length());
+		String[] split = substring.split("/");
+		return new SymbolInterval(split[0].toLowerCase(), split[1]);
+	}
+
+	@AllArgsConstructor
+	public static class SymbolInterval {
+		private final String symbol;
+		private final String interval;
+	}
+}


### PR DESCRIPTION
사용자가 특정 차트 토픽을 구독하는 순간, 백엔드가 실시간으로 이를 감지하여 바이낸스에 해당 Kline 스트림 구독을 요청하고, 마지막 사용자가 구독을 해제하면 바이낸스와의 구독도 자동으로 해제하는 아키텍처

1. Kline 데이터 수신 분리 (KlineStreamReceiver)
- Trade 스트림과 분리하여, 오직 Kline 데이터 수신 및 처리에만 집중하는 KlineStreamReceiver를 구현
- 수신된 데이터는 TradingView 차트 라이브러리 포맷에 맞게 가공된 후, 내부 Redis Pub/Sub 채널로 발행

2. 세션 관리자 도입 (KlineStreamManager)
- KlineStreamReceiver가 바이낸스와 맺은 WebSocketSession을 중앙에서 관리하는 역할
- klineSubscriptionManager의 요청에 따라, 현재 활성화된 세션을 통해 바이낸스로 SUBSCRIBE 또는 UNSUBSCRIBE 명령을 전송
- 
3. 실시간 구독 상태 관리 (klineSubscriptionManager)
- 기존 StompSessionEventListener와 Redis를 통해 사용자의 구독 상태를 실시간으로 추적
- onFirstSubscriber(): 특정 Kline 토픽(예: /topic/crypto/kline/BTC/1m)에 첫 번째 구독자가 생기면, KlineStreamManager를 호출하여 바이낸스에 해당 스트림(BTCUSDT@kline_1m) 구독을 요청
- onLastSubscriber(): 해당 토픽의 마지막 구독자가 떠나면, KlineStreamManager를 호출하여 바이낸스에 해당 스트림 구독 해제를 요청