### PR TITLE
feat: 차트 초기 로딩을 위한 과거 Kline 데이터 API 구현

### DIFF
--- a/src/main/java/com/zunza/buythedip/config/WebSocketConfig.java
+++ b/src/main/java/com/zunza/buythedip/config/WebSocketConfig.java
@@ -26,7 +26,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
 	@Override
 	public void configureMessageBroker(MessageBrokerRegistry registry) {
-		registry.enableSimpleBroker("/topic");
+		registry.enableSimpleBroker("/topic", "/queue");
 		registry.setApplicationDestinationPrefixes("/app");
 	}
 

--- a/src/main/java/com/zunza/buythedip/cryptocurrency/client/BinanceClient.java
+++ b/src/main/java/com/zunza/buythedip/cryptocurrency/client/BinanceClient.java
@@ -1,15 +1,19 @@
 package com.zunza.buythedip.cryptocurrency.client;
 
+
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.util.List;
 
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zunza.buythedip.cryptocurrency.dto.binance.ExchangeInfoDto;
+import com.zunza.buythedip.cryptocurrency.dto.binance.KlineDto;
 
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
@@ -65,6 +69,22 @@ public class BinanceClient {
 			.bodyToMono(String.class)
 			.map(res -> parseOpenPrice(res, symbol))
 			.onErrorReturn(Double.NaN);
+	}
+
+	public Mono<List<KlineDto>> getKlines(String symbol, String interval) {
+		return webClient.get()
+			.uri(uriBuilder -> uriBuilder
+				.path("/api/v3/klines")
+				.queryParam("symbol", symbol)
+				.queryParam("interval", interval)
+				.queryParam("limit", 100)
+				.build()
+			)
+			.retrieve()
+			.bodyToMono(new ParameterizedTypeReference<List<List<Object>>>() {})
+			.map(res -> res.stream()
+				.map(KlineDto::createKlineDtoForInit)
+				.toList());
 	}
 
 	private Double parseOpenPrice(String res, String symbol) {

--- a/src/main/java/com/zunza/buythedip/cryptocurrency/controller/CryptocurrencyController.java
+++ b/src/main/java/com/zunza/buythedip/cryptocurrency/controller/CryptocurrencyController.java
@@ -1,0 +1,44 @@
+package com.zunza.buythedip.cryptocurrency.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.zunza.buythedip.cryptocurrency.dto.CryptoInfoDto;
+import com.zunza.buythedip.cryptocurrency.dto.InitKlineDto;
+import com.zunza.buythedip.cryptocurrency.dto.RankingDto;
+import com.zunza.buythedip.cryptocurrency.service.CryptocurrencyService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class CryptocurrencyController {
+
+	private final CryptocurrencyService cryptocurrencyService;
+
+	@GetMapping("/api/crypto/{cryptocurrencyId}/info")
+	public ResponseEntity<CryptoInfoDto> getCryptoInfo(
+		@PathVariable Long cryptocurrencyId
+	) {
+		return ResponseEntity.ok(cryptocurrencyService.getInfo(cryptocurrencyId));
+	}
+
+	@GetMapping("/api/crypto/volume/top")
+	public ResponseEntity<List<RankingDto>> getTopVolumeRanking() {
+		return ResponseEntity.ok(cryptocurrencyService.getTopVolume());
+	}
+
+	@MessageMapping("/crypto/kline")
+	public void getHistoricalCandles(
+		InitKlineDto initKlineDto
+	) {
+		cryptocurrencyService.getHistoricalCandles(initKlineDto.getSymbol(), initKlineDto.getInterval());
+	}
+}

--- a/src/main/java/com/zunza/buythedip/cryptocurrency/dto/InitKlineDto.java
+++ b/src/main/java/com/zunza/buythedip/cryptocurrency/dto/InitKlineDto.java
@@ -1,0 +1,11 @@
+package com.zunza.buythedip.cryptocurrency.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class InitKlineDto {
+	private String symbol;
+	private String interval;
+}

--- a/src/main/java/com/zunza/buythedip/cryptocurrency/dto/SubDto.java
+++ b/src/main/java/com/zunza/buythedip/cryptocurrency/dto/SubDto.java
@@ -1,0 +1,18 @@
+package com.zunza.buythedip.cryptocurrency.dto;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class SubDto {
+	private String method;
+	private List<String> params;
+	private String id;
+
+	public SubDto(String method, List<String> params, String id) {
+		this.method = method;
+		this.params = params;
+		this.id = id;
+	}
+}

--- a/src/main/java/com/zunza/buythedip/cryptocurrency/service/CryptocurrencyService.java
+++ b/src/main/java/com/zunza/buythedip/cryptocurrency/service/CryptocurrencyService.java
@@ -1,0 +1,74 @@
+package com.zunza.buythedip.cryptocurrency.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Service;
+
+import com.zunza.buythedip.cryptocurrency.client.BinanceClient;
+import com.zunza.buythedip.cryptocurrency.dto.CryptoDataWithLogoDto;
+import com.zunza.buythedip.cryptocurrency.dto.CryptoInfoDto;
+import com.zunza.buythedip.cryptocurrency.dto.RankingDto;
+import com.zunza.buythedip.cryptocurrency.dto.binance.KlineDto;
+import com.zunza.buythedip.cryptocurrency.exception.CryptoCurrencyNotFoundException;
+import com.zunza.buythedip.cryptocurrency.repository.CryptocurrencyRepository;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class CryptocurrencyService {
+
+	private final CryptocurrencyRepository cryptocurrencyRepository;
+	private final SimpMessageSendingOperations messagingTemplate;
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final BinanceClient binanceClient;
+
+	private static final String MINUTE_BUCKET_KEY_PREFIX = "tv:";
+	private static final String AGGREGATED_VOLUME_KEY = MINUTE_BUCKET_KEY_PREFIX + "30m_aggregated";
+	private static final int TOP_N = 50;
+
+	public CryptoInfoDto getInfo(Long cryptocurrencyId) {
+		return cryptocurrencyRepository.findByIdWithMetadata(cryptocurrencyId)
+			.orElseThrow(() -> new CryptoCurrencyNotFoundException(cryptocurrencyId));
+	}
+
+	public List<RankingDto> getTopVolume() {
+		Set<ZSetOperations.TypedTuple<Object>> zset = redisTemplate.opsForZSet()
+			.reverseRangeWithScores(AGGREGATED_VOLUME_KEY, 0, TOP_N - 1);
+
+		Map<String, CryptoDataWithLogoDto> cryptoMap = cryptocurrencyRepository.findAllWithLogo()
+			.stream()
+			.collect(Collectors.toMap(CryptoDataWithLogoDto::getSymbol, c -> c));
+
+		return zset.stream()
+			.map(tuple -> {
+				String symbol = tuple.getValue().toString().replace("USDT", "");
+				CryptoDataWithLogoDto crypto = cryptoMap.get(symbol);
+
+				return RankingDto.of(
+					crypto.getId(),
+					crypto.getName(),
+					crypto.getSymbol(),
+					crypto.getLogo(),
+					Double.parseDouble(tuple.getScore().toString()));
+			})
+			.toList();
+	}
+
+	public void getHistoricalCandles(String symbol, String interval) {
+		Mono<List<KlineDto>> klines = binanceClient.getKlines(symbol + "USDT", interval);
+
+		klines.subscribe(candles ->
+			messagingTemplate.convertAndSend(
+				"/queue/crypto/kline/" + symbol + "/" + interval,
+				candles)
+			);
+	}
+}


### PR DESCRIPTION
WebClient를 사용하여 바이낸스의 REST API(api/v3/klines)를 논블로킹 방식으로 호출하고, 조회된 과거 데이터를 STOMP를 통해 요청한 특정 사용자에게만 전송하는 파이프라인을 구축
- 실시간 WebSocket 스트림은 연결된 시점 이후의 데이터만 제공하므로, 사용자가 차트를 처음 볼 때 비어있는 화면이 표시됨
- 차트의 초기 상태를 구성하기 위해, 최근 100개의 캔들 데이터를 먼저 불러와 차트를 그린 후, 실시간 데이터로 업데이트하는 사용자 경험을 제공

1. 클라이언트 요청 (@MessageMapping)
- 클라이언트는 차트에 필요한 종목과 인터벌(예: BTC, 1m)을 담아 STOMP 메시지를 /app/crypto/kline 목적지로 전송

2. 비동기 데이터 조회
- CryptocurrencyController -> CryptocurrencyService는 요청을 받아, WebClient를 사용하여 바이낸스 REST API에 과거 데이터 조회를 요청

3. 결과 전송
- klines.subscribe(...)를 호출하여, Mono가 데이터를 성공적으로 받아왔을 때 실행될 작업을 정의
- SimpMessagingTemplate을 사용하여, 조회된 과거 캔들 데이터 리스트(List<KlineDto>)를 요청한 사용자의 개인 큐(예: /queue/crypto/kline/BTC/1m)로 전송