### PR TITLE
feat: 매일 자정(UTC)에 코인의 시가를 가져오는 스케쥴러 구현

### DIFF
--- a/src/main/java/com/zunza/buythedip/cryptocurrency/scheduler/OpenPriceScheduler.java
+++ b/src/main/java/com/zunza/buythedip/cryptocurrency/scheduler/OpenPriceScheduler.java
@@ -1,0 +1,46 @@
+package com.zunza.buythedip.cryptocurrency.scheduler;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import com.zunza.buythedip.cryptocurrency.client.BinanceClient;
+import com.zunza.buythedip.cryptocurrency.entity.Cryptocurrency;
+import com.zunza.buythedip.cryptocurrency.repository.CryptocurrencyRepository;
+import com.zunza.buythedip.cryptocurrency.repository.OpenPriceCacheRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Flux;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OpenPriceScheduler {
+
+	private final CryptocurrencyRepository cryptoCurrencyRepository;
+	private final OpenPriceCacheRepository openPriceCacheRepository;
+	private final BinanceClient binanceClient;
+
+	private static final String SYMBOL_SUFFIX = "USDT";
+	private static final String KEY_SUFFIX_OPEN_PRICE = ":OPENPRICE";
+
+	@Scheduled(cron = "10 0 0 * * *", zone = "UTC")
+	public void fetchAndCacheAllSymbolsOpenPrice() {
+		List<Cryptocurrency> cryptocurrencies = cryptoCurrencyRepository.findAll();
+		LocalDate now = LocalDate.now();
+
+		Flux.fromIterable(cryptocurrencies)
+			.delayElements(Duration.ofMillis(100))
+			.flatMap(cryptocurrency -> binanceClient.getDailyOpenPrice(cryptocurrency.getSymbol() + SYMBOL_SUFFIX, now)
+				.doOnNext(openPrice -> {
+					openPriceCacheRepository.save(cryptocurrency.getSymbol() + SYMBOL_SUFFIX + KEY_SUFFIX_OPEN_PRICE, openPrice);
+					log.info("Successfully cached symbol: {} / open price: {}", cryptocurrency.getSymbol() + SYMBOL_SUFFIX, openPrice);
+				})
+			)
+			.subscribe();
+	}
+}


### PR DESCRIPTION
서비스 내에서 각 암호화폐의 당일 등락률을 계산하기 위해서는 기준점이 되는 당일 시가 데이터가 필요
매번 등락률을 계산할 때마다 외부 API를 호출하는 것은 매우 비효율적이고 API 사용량 제한에 걸릴 위험이 있음
따라서, 하루에 한 번 장이 1일봉이 바뀌는 시점(UTC 00:00)에 모든 코인의 시가 정보를 미리 가져와 캐시에 저장해두고, 캐시 데이터를 사용하여 빠르게 등락률을 계산하는 것이  목적

1. 스케줄링 (@Scheduled)
- @Scheduled(cron = "10 0 0 * * *", zone = "UTC") 어노테이션을 사용하여 매일 UTC 00시 00분 10초에 fetchAndCacheAllSymbolsOpenPrice() 메서드가 자동으로 실행되도록 설정.

2. 비동기 API 호출
- DB에서 서비스하는 모든 암호화폐 목록을 조회한 뒤, Flux.fromIterable()을 사용하여 각 암호화폐에 대한 API 호출을 비동기 스트림으로 변환
- flatMap 연산자 내에서 WebClient(binanceClient)를 호출하여, 여러 개의 API 요청을  처리

3. Rate Limiting 
- 바이낸스의 API 요청 횟수 제한을 준수하고, 짧은 시간에 과도한 요청으로 인해 IP가 차단되는 것을 방지하기 위해 delayElements(Duration.ofMillis(100))를 사용했습니다.

4. 캐시 저장
- API 호출이 성공적으로 완료될 때마다(doOnNext), 해당 코인의 시가 정보를 Redis에 즉시 저장