### PR TITLE
refactor: 웹소켓 세션 관리 로직 개선

### DIFF
--- a/src/main/java/com/zunza/buythedip/session/RedisKeyPrefix.java
+++ b/src/main/java/com/zunza/buythedip/session/RedisKeyPrefix.java
@@ -1,0 +1,24 @@
+package com.zunza.buythedip.session;
+
+import lombok.Getter;
+
+@Getter
+public enum RedisKeyPrefix {
+    SUBSCRIBER_COUNT("subscribers:count:"),
+    SESSION_SUBSCRIPTIONS("session:subs:"),
+    SUBSCRIPTION_DESTINATION("sub:dest:");
+
+    private final String prefix;
+
+    RedisKeyPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    public String getKey(String suffix) {
+        return prefix + suffix;
+    }
+    
+    public String getKey(String... suffixes) {
+        return prefix + String.join(":", suffixes);
+    }
+}

--- a/src/main/java/com/zunza/buythedip/session/SessionEventManager.java
+++ b/src/main/java/com/zunza/buythedip/session/SessionEventManager.java
@@ -1,22 +1,18 @@
 package com.zunza.buythedip.session;
 
-import java.io.IOException;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
+import com.zunza.buythedip.session.manage.AbstractSubscriptionManager;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.connection.RedisConnection;
-import org.springframework.data.redis.core.Cursor;
-import org.springframework.data.redis.core.RedisConnectionUtils;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.*;
 import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.stereotype.Component;
 
-import com.zunza.buythedip.session.manage.AbstractSubscriptionManager;
-
-import lombok.extern.slf4j.Slf4j;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 @Slf4j
 @Component
@@ -24,17 +20,6 @@ public class SessionEventManager {
 
 	private final Map<String, AbstractSubscriptionManager> managerMap;
 	private final RedisTemplate<String, Object> redisTemplate;
-
-	private static final String SUBSCRIBER_COUNT_KEY_PREFIX = "subscribers:count:";
-	private static final String SESSION_SUBSCRIPTIONS_KEY_PREFIX = "session:subs:";
-	private static final String SUBSCRIPTION_DESTINATION_KEY_PREFIX = "sub:dest:";
-
-	private static final String TRADE_DESTINATION_PREFIX = "/topic/crypto/trade";
-	private static final String KLINE_DESTINATION_PREFIX = "/topic/crypto/kline";
-
-	private static final String TRADE_MANAGER_KEY = "trade";
-	private static final String KLINE_MANAGER_KEY = "kline";
-	private static final String CHAT_MANAGER_KEY = "chat";
 
 	public SessionEventManager(
 		@Qualifier("tradeSubscriptionManager") AbstractSubscriptionManager tradeSubscriptionManger,
@@ -44,9 +29,9 @@ public class SessionEventManager {
 	) {
 		this.redisTemplate = redisTemplate;
 		this.managerMap = Map.of(
-			TRADE_MANAGER_KEY, tradeSubscriptionManger,
-			KLINE_MANAGER_KEY, klineSubscriptionManger,
-			CHAT_MANAGER_KEY, chatSubscriptionManger
+			SubscriptionType.TRADE.getManagerKey(), tradeSubscriptionManger,
+			SubscriptionType.KLINE.getManagerKey(), klineSubscriptionManger,
+			SubscriptionType.CHAT.getManagerKey(), chatSubscriptionManger
 		);
 	}
 
@@ -71,40 +56,24 @@ public class SessionEventManager {
 		Set<Object> destinations = getSubscribedDestinationForSession(sessionId);
 		destinations.forEach(d -> {
 			String destination = String.valueOf(d);
-			String key = getKeyForManagerMap(String.valueOf(destination));
-
-			if (KLINE_MANAGER_KEY.equals(key)) {
-				try {
-					Long subscriberCount = decrementSubscriberCounts(destination);
-					redisTemplate.opsForSet().remove(getSessionKey(sessionId), destination);
-					log.info("[Disconnected] Unsubscribed from {} | Current subscribers: {}", destination, subscriberCount);
-					managerMap.get(key).onLastSubscriber(destination, subscriberCount);
-				} catch (IOException e) {
-					throw new RuntimeException(e);
-				}
-			} else {
-				Long subscriberCount = decrementSubscriberCounts(destination);
-				redisTemplate.opsForSet().remove(getSessionKey(sessionId), destination);
-				log.info("[Disconnected] Unsubscribed from {} | Current subscribers: {}", destination, subscriberCount);
+			String key = getKeyForManagerMap(destination);
+			try {
+				managerMap.get(key).handleDisconnect(sessionId, destination);
+			} catch (IOException e) {
+				log.error("Error during disconnect for destination {}: {}", destination, e.getMessage(), e);
 			}
 		});
 
-		String pattern = SUBSCRIPTION_DESTINATION_KEY_PREFIX + sessionId + ":*";
+		String pattern = RedisKeyPrefix.SUBSCRIPTION_DESTINATION.getKey(sessionId, "*");
 		deleteSubDestinations(pattern);
 	}
 
 	private String getKeyForManagerMap(String destination) {
-		if (destination.startsWith(TRADE_DESTINATION_PREFIX)) {
-			return TRADE_MANAGER_KEY;
-		} else if (destination.startsWith(KLINE_DESTINATION_PREFIX)) {
-			return KLINE_MANAGER_KEY;
-		} else {
-			return CHAT_MANAGER_KEY;
-		}
+		return SubscriptionType.from(destination).getManagerKey();
 	}
 
 	private String getSubDestinationKey(String sessionId, String subscriptionId) {
-		return SUBSCRIPTION_DESTINATION_KEY_PREFIX + sessionId + ":" + subscriptionId;
+		return RedisKeyPrefix.SUBSCRIPTION_DESTINATION.getKey(sessionId, subscriptionId);
 	}
 
 	private String getDestinationBySubDestinationKey(String key) {
@@ -112,46 +81,34 @@ public class SessionEventManager {
 	}
 
 	private String getSessionKey(String sessionId) {
-		return SESSION_SUBSCRIPTIONS_KEY_PREFIX + sessionId;
+		return RedisKeyPrefix.SESSION_SUBSCRIPTIONS.getKey(sessionId);
 	}
 
 	private Set<Object> getSubscribedDestinationForSession(String sessionId) {
 		return redisTemplate.opsForSet().members(getSessionKey(sessionId));
 	}
 
-	private String getCountKey(String destination) {
-		return SUBSCRIBER_COUNT_KEY_PREFIX + destination;
-	}
-
-	private Long decrementSubscriberCounts(String destination) {
-		String countKey = getCountKey(destination);
-		return redisTemplate.opsForValue().decrement(countKey);
-	}
-
 	private void deleteSubDestinations(String pattern) {
-		ScanOptions options = ScanOptions.scanOptions()
+		ScanOptions options = KeyScanOptions.scanOptions()
 			.match(pattern)
 			.count(50)
 			.build();
 
-		RedisConnection connection = RedisConnectionUtils.getConnection(redisTemplate.getConnectionFactory());
-		RedisSerializer<String> serializer = redisTemplate.getStringSerializer();
+		Set<String> keys = redisTemplate.execute((RedisConnection connection) -> {
+			RedisSerializer<String> serializer = redisTemplate.getStringSerializer();
+			Set<String> results = new HashSet<>();
 
-		Set<String> keysToDelete = new HashSet<>();
-
-		try (Cursor<byte[]> cursor = connection.scan(options)) {
-			while (cursor.hasNext()) {
-				String key = serializer.deserialize(cursor.next());
-				keysToDelete.add(key);
+			try (Cursor<byte[]> cursor = connection.keyCommands().scan(options)) {
+				while (cursor.hasNext()) {
+					String key = serializer.deserialize(cursor.next());
+					Optional.ofNullable(key).ifPresent(results::add);
+				}
 			}
-		} catch (Exception e) {
-			throw new RuntimeException("Error during SCAN operation", e);
-		} finally {
-			RedisConnectionUtils.releaseConnection(connection, redisTemplate.getConnectionFactory());
-		}
+			return results;
+		});
 
-		if (!keysToDelete.isEmpty()) {
-			redisTemplate.delete(keysToDelete);
+		if (!keys.isEmpty()) {
+			redisTemplate.delete(keys);
 		}
 	}
 }

--- a/src/main/java/com/zunza/buythedip/session/SubscriptionType.java
+++ b/src/main/java/com/zunza/buythedip/session/SubscriptionType.java
@@ -1,0 +1,30 @@
+package com.zunza.buythedip.session;
+
+import lombok.Getter;
+
+@Getter
+public enum SubscriptionType {
+    TRADE("/topic/crypto/trade", "trade"),
+    KLINE("/topic/crypto/kline", "kline"),
+    CHAT("/topic/chat", "chat");
+
+    private final String destinationPrefix;
+    private final String managerKey;
+
+    SubscriptionType(String destinationPrefix, String managerKey) {
+        this.destinationPrefix = destinationPrefix;
+        this.managerKey = managerKey;
+    }
+
+    public static SubscriptionType from(String destination) {
+        if (destination == null) {
+            return CHAT;
+        }
+        for (SubscriptionType type : values()) {
+            if (destination.startsWith(type.destinationPrefix)) {
+                return type;
+            }
+        }
+        return CHAT;
+    }
+}

--- a/src/main/java/com/zunza/buythedip/session/manage/AbstractSubscriptionManager.java
+++ b/src/main/java/com/zunza/buythedip/session/manage/AbstractSubscriptionManager.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 
 import org.springframework.data.redis.core.RedisTemplate;
 
+import com.zunza.buythedip.session.RedisKeyPrefix;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -11,15 +13,11 @@ public abstract class AbstractSubscriptionManager {
 
 	protected final RedisTemplate<String, Object> redisTemplate;
 
-	private static final String SUBSCRIBER_COUNT_KEY_PREFIX = "subscribers:count:";
-	private static final String SESSION_SUBSCRIPTIONS_KEY_PREFIX = "session:subs:";
-	private static final String SUBSCRIPTION_DESTINATION_KEY_PREFIX = "sub:dest:";
-
 	protected AbstractSubscriptionManager(RedisTemplate<String, Object> redisTemplate) {
 		this.redisTemplate = redisTemplate;
 	}
 
-	public void handleSubscribe(String sessionId, String subscriptionId, String destination) throws IOException {
+	public final void handleSubscribe(String sessionId, String subscriptionId, String destination) throws IOException {
 		String countKey = getCountKey(destination);
 		Long subscriberCount = redisTemplate.opsForValue().increment(countKey);
 		log.info("Subscribed to {} | Current subscribers: {}", destination, subscriberCount);
@@ -29,9 +27,11 @@ public abstract class AbstractSubscriptionManager {
 
 		String subDestinationKey = getSubDestinationKey(sessionId, subscriptionId);
 		redisTemplate.opsForValue().set(subDestinationKey, destination);
+
+		onFirstSubscriber(destination, subscriberCount);
 	}
 
-	public void handleUnSubscribe(String sessionId, String subscriptionId) throws IOException {
+	public final void handleUnSubscribe(String sessionId, String subscriptionId) throws IOException {
 		String subDestinationKey = getSubDestinationKey(sessionId, subscriptionId);
 		String destination = String.valueOf(redisTemplate.opsForValue().get(subDestinationKey));
 
@@ -42,19 +42,32 @@ public abstract class AbstractSubscriptionManager {
 		String sessionKey = getSessionKey(sessionId);
 		redisTemplate.opsForSet().remove(sessionKey, destination);
 		redisTemplate.delete(subDestinationKey);
+
+		onLastSubscriber(destination, subscriberCount);
 	}
 
-	public abstract void onLastSubscriber(String destination, Long subscriberCount) throws IOException;
+	public abstract void handleDisconnect(String sessionId, String destination) throws IOException;
+
+	public void onFirstSubscriber(String destination, Long subscriberCount) throws IOException {
+	}
+
+	public void onLastSubscriber(String destination, Long subscriberCount) throws IOException {
+	}
 
 	protected String getCountKey(String destination) {
-		return SUBSCRIBER_COUNT_KEY_PREFIX + destination;
+		return RedisKeyPrefix.SUBSCRIBER_COUNT.getKey(destination);
 	}
 
 	protected String getSessionKey(String sessionId) {
-		return SESSION_SUBSCRIPTIONS_KEY_PREFIX + sessionId;
+		return RedisKeyPrefix.SESSION_SUBSCRIPTIONS.getKey(sessionId);
 	}
 
 	protected String getSubDestinationKey(String sessionId, String subscriptionId) {
-		return SUBSCRIPTION_DESTINATION_KEY_PREFIX + sessionId + ":" + subscriptionId;
+		return RedisKeyPrefix.SUBSCRIPTION_DESTINATION.getKey(sessionId, subscriptionId);
 	}
+
+    protected Long decrementSubscriberCounts(String destination) {
+        String countKey = getCountKey(destination);
+        return redisTemplate.opsForValue().decrement(countKey);
+    }
 }

--- a/src/main/java/com/zunza/buythedip/session/manage/ChatSubscriptionManager.java
+++ b/src/main/java/com/zunza/buythedip/session/manage/ChatSubscriptionManager.java
@@ -1,5 +1,7 @@
 package com.zunza.buythedip.session.manage;
 
+import java.io.IOException;
+
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -14,5 +16,13 @@ public class ChatSubscriptionManager extends AbstractSubscriptionManager {
 	}
 
 	@Override
-	public void onLastSubscriber(String destination, Long subscriberCount) {}
+	public void handleDisconnect(String sessionId, String destination) {
+		Long subscriberCount = decrementSubscriberCounts(destination);
+		redisTemplate.opsForSet().remove(getSessionKey(sessionId), destination);
+		log.info("[Disconnected] Unsubscribed from {} | Current subscribers: {}", destination, subscriberCount);
+	}
+
+	@Override
+	public void onLastSubscriber(String destination, Long subscriberCount) {
+	}
 }

--- a/src/main/java/com/zunza/buythedip/session/manage/TradeSubscriptionManager.java
+++ b/src/main/java/com/zunza/buythedip/session/manage/TradeSubscriptionManager.java
@@ -1,6 +1,8 @@
 package com.zunza.buythedip.session.manage;
 
 
+import java.io.IOException;
+
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -15,5 +17,13 @@ public class TradeSubscriptionManager extends AbstractSubscriptionManager {
 	}
 
 	@Override
-	public void onLastSubscriber(String destination, Long subscriberCount) {}
+	public void handleDisconnect(String sessionId, String destination) {
+		Long subscriberCount = decrementSubscriberCounts(destination);
+		redisTemplate.opsForSet().remove(getSessionKey(sessionId), destination);
+		log.info("[Disconnected] Unsubscribed from {} | Current subscribers: {}", destination, subscriberCount);
+	}
+
+	@Override
+	public void onLastSubscriber(String destination, Long subscriberCount) {
+	}
 }

--- a/src/main/java/com/zunza/buythedip/session/manage/klineSubscriptionManager.java
+++ b/src/main/java/com/zunza/buythedip/session/manage/klineSubscriptionManager.java
@@ -26,37 +26,15 @@ public class klineSubscriptionManager extends AbstractSubscriptionManager {
 	}
 
 	@Override
-	public void handleSubscribe(String sessionId, String subscriptionId, String destination) throws IOException {
-		String countKey = getCountKey(destination);
-		Long subscriberCount = redisTemplate.opsForValue().increment(countKey);
-		log.info("Subscribed to {} | Current subscribers: {}", destination, subscriberCount);
-
-		String sessionKey = getSessionKey(sessionId);
-		redisTemplate.opsForSet().add(sessionKey, destination);
-
-		String subDestinationKey = getSubDestinationKey(sessionId, subscriptionId);
-		redisTemplate.opsForValue().set(subDestinationKey, destination);
-
-		onFirstSubscriber(destination, subscriberCount);
-	}
-
-	@Override
-	public void handleUnSubscribe(String sessionId, String subscriptionId) throws IOException {
-		String subDestinationKey = getSubDestinationKey(sessionId, subscriptionId);
-		String destination = String.valueOf(redisTemplate.opsForValue().get(subDestinationKey));
-
-		String countKey = getCountKey(destination);
-		Long subscriberCount = redisTemplate.opsForValue().decrement(countKey);
-		log.info("Unsubscribed from {} | Current subscribers: {}", destination, subscriberCount);
-
-		String sessionKey = getSessionKey(sessionId);
-		redisTemplate.opsForSet().remove(sessionKey, destination);
-		redisTemplate.delete(subDestinationKey);
-
+	public void handleDisconnect(String sessionId, String destination) throws IOException {
+		Long subscriberCount = decrementSubscriberCounts(destination);
+		redisTemplate.opsForSet().remove(getSessionKey(sessionId), destination);
+		log.info("[Disconnected] Unsubscribed from {} | Current subscribers: {}", destination, subscriberCount);
 		onLastSubscriber(destination, subscriberCount);
 	}
 
-	private void onFirstSubscriber(String destination, Long subscriberCount) throws IOException {
+	@Override
+	public void onFirstSubscriber(String destination, Long subscriberCount) throws IOException {
 		if (subscriberCount != null && subscriberCount == 1) {
 			SymbolInterval symbolInterval = extractSymbolAndInterval(destination);
 			klineStreamManager.subKlineForSymbol(symbolInterval.symbol, symbolInterval.interval);


### PR DESCRIPTION
1. SubscriptionType Enum 도입
- 구독 destination prefix와 manager key를 관리하는 SubscriptionType enum을 생성
- SessionEventManager에서 하드코딩된 문자열 대신 이 enum을 사용하도록 변경

2. RedisKeyPrefix Enum을 통한 Redis 키 관리
- 여러 클래스에 흩어져 있던 Redis 키 prefix들을 RedisKeyPrefix enum으로 통합

3. 템플릿 메소드 패턴을 이용한 AbstractSubscriptionManager 리팩토링
- handleSubscribe, handleUnSubscribe를 템플릿 메소드로 변경하고, 자식 클래스가 특정 로직을 구현할 수 있는 onFirstSubscriber, onLastSubscriber 훅 메소드를 도입
- klineSubscriptionManager의 중복 코드를 제거하고, 각 매니저가 자신의 역할에만 집중하도록 구조를 개선

4. SessionEventManager 책임 분리
- SessionEventManager의 disConnect 메소드에 있던 분기 로직을 각 SubscriptionManager의 handleDisconnect 메소드로 위임
- SessionEventManager는 이벤트를 받아 적절한 매니저에게 전달