### PR TITLE
feat: 댓글 및 대댓글 CRUD API 추가

### DIFF
--- a/src/main/java/com/zunza/buythedip/community/controller/CommentController.java
+++ b/src/main/java/com/zunza/buythedip/community/controller/CommentController.java
@@ -1,0 +1,65 @@
+package com.zunza.buythedip.community.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.zunza.buythedip.community.dto.CreateCommentDto;
+import com.zunza.buythedip.community.dto.CreateReplyDto;
+import com.zunza.buythedip.community.dto.ModifyCommentRequestDto;
+import com.zunza.buythedip.community.service.CommentService;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class CommentController {
+
+	private final CommentService commentService;
+
+	@PostMapping("/api/posts/{postId}/comments")
+	public ResponseEntity<Void> crateComment(
+		@AuthenticationPrincipal Long userId,
+		@PathVariable Long postId,
+		@RequestBody CreateCommentDto createCommentDto
+	) {
+		commentService.createComment(userId, postId, createCommentDto);
+		return ResponseEntity.status(HttpServletResponse.SC_CREATED).build();
+	}
+
+	@PostMapping("/api/posts/{postId}/comments/{commentId}/replies")
+	public ResponseEntity<Void> createReply(
+		@AuthenticationPrincipal Long userId,
+		@PathVariable Long postId,
+		@PathVariable Long commentId,
+		@RequestBody CreateReplyDto createReplyDto
+	) {
+		commentService.createReply(userId, postId, commentId, createReplyDto);
+		return ResponseEntity.status(HttpServletResponse.SC_CREATED).build();
+	}
+
+	@PatchMapping("/api/comments/{commentId}")
+	public ResponseEntity<Void> modifyComment(
+		@AuthenticationPrincipal Long userId,
+		@PathVariable Long commentId,
+		@RequestBody ModifyCommentRequestDto modifyCommentRequestDto
+	) {
+		commentService.modifyComment(userId, commentId, modifyCommentRequestDto);
+		return ResponseEntity.status(HttpServletResponse.SC_NO_CONTENT).build();
+	}
+
+	@DeleteMapping("/api/comments/{commentId}")
+	public ResponseEntity<Void> deleteComment(
+		@AuthenticationPrincipal Long userId,
+		@PathVariable Long commentId
+	) {
+		commentService.deleteComment(userId, commentId);
+		return ResponseEntity.status(HttpServletResponse.SC_NO_CONTENT).build();
+	}
+}

--- a/src/main/java/com/zunza/buythedip/community/dto/CreateCommentDto.java
+++ b/src/main/java/com/zunza/buythedip/community/dto/CreateCommentDto.java
@@ -1,0 +1,8 @@
+package com.zunza.buythedip.community.dto;
+
+import lombok.Getter;
+
+@Getter
+public class CreateCommentDto {
+	private String content;
+}

--- a/src/main/java/com/zunza/buythedip/community/dto/CreateReplyDto.java
+++ b/src/main/java/com/zunza/buythedip/community/dto/CreateReplyDto.java
@@ -1,0 +1,8 @@
+package com.zunza.buythedip.community.dto;
+
+import lombok.Getter;
+
+@Getter
+public class CreateReplyDto {
+	private String content;
+}

--- a/src/main/java/com/zunza/buythedip/community/dto/ModifyCommentRequestDto.java
+++ b/src/main/java/com/zunza/buythedip/community/dto/ModifyCommentRequestDto.java
@@ -1,0 +1,8 @@
+package com.zunza.buythedip.community.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ModifyCommentRequestDto {
+	private String content;
+}

--- a/src/main/java/com/zunza/buythedip/community/dto/ModifyPostRequestDto.java
+++ b/src/main/java/com/zunza/buythedip/community/dto/ModifyPostRequestDto.java
@@ -1,0 +1,9 @@
+package com.zunza.buythedip.community.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ModifyPostRequestDto {
+	private String title;
+	private String content;
+}

--- a/src/main/java/com/zunza/buythedip/community/entity/Comment.java
+++ b/src/main/java/com/zunza/buythedip/community/entity/Comment.java
@@ -8,6 +8,7 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import com.zunza.buythedip.community.dto.ModifyCommentRequestDto;
 import com.zunza.buythedip.user.entity.User;
 
 import jakarta.persistence.CascadeType;
@@ -23,6 +24,7 @@ import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -53,7 +55,7 @@ public class Comment {
 	private Comment parent;
 
 	@OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<Comment> children = new ArrayList<>();
+	private List<Comment> replies = new ArrayList<>();
 
 	@OneToMany(mappedBy = "comment", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<CommentLike> likes = new ArrayList<>();
@@ -63,4 +65,33 @@ public class Comment {
 
 	@UpdateTimestamp
 	private LocalDateTime updatedAt;
+
+	@Builder
+	private Comment(String content, User author, Post post, Comment parent) {
+		this.content = content;
+		this.author = author;
+		this.post = post;
+		this.parent = parent;
+	}
+
+	public static Comment createComment(String content, User author, Post post) {
+		return Comment.builder()
+			.content(content)
+			.author(author)
+			.post(post)
+			.build();
+	}
+
+	public static Comment createReply(String content, User author, Post post, Comment parent) {
+		return Comment.builder()
+			.content(content)
+			.author(author)
+			.post(post)
+			.parent(parent)
+			.build();
+	}
+
+	public void modifyContent(ModifyCommentRequestDto modifyCommentRequestDto) {
+		this.content = modifyCommentRequestDto.getContent();
+	}
 }

--- a/src/main/java/com/zunza/buythedip/community/exception/CommentNotFoundException.java
+++ b/src/main/java/com/zunza/buythedip/community/exception/CommentNotFoundException.java
@@ -1,0 +1,19 @@
+package com.zunza.buythedip.community.exception;
+
+import com.zunza.buythedip.common.CustomException;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+public class CommentNotFoundException extends CustomException {
+
+	private static final String MESSAGE = "존재하지 않는 댓글 입니다. COMMENT ID: ";
+
+	public CommentNotFoundException(Long commentId) {
+		super(MESSAGE + commentId);
+	}
+
+	@Override
+	public int getStatusCode() {
+		return HttpServletResponse.SC_NOT_FOUND;
+	}
+}

--- a/src/main/java/com/zunza/buythedip/community/repository/comment/CommentRepository.java
+++ b/src/main/java/com/zunza/buythedip/community/repository/comment/CommentRepository.java
@@ -1,0 +1,15 @@
+package com.zunza.buythedip.community.repository.comment;
+
+
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.zunza.buythedip.community.entity.Comment;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long>, QuerydslCommentRepository {
+	Optional<Comment> findByIdAndAuthorId(Long commentId, Long userId);
+}

--- a/src/main/java/com/zunza/buythedip/community/service/CommentService.java
+++ b/src/main/java/com/zunza/buythedip/community/service/CommentService.java
@@ -1,0 +1,66 @@
+package com.zunza.buythedip.community.service;
+
+import org.springframework.stereotype.Service;
+
+import com.zunza.buythedip.community.dto.CreateCommentDto;
+import com.zunza.buythedip.community.dto.CreateReplyDto;
+import com.zunza.buythedip.community.dto.ModifyCommentRequestDto;
+import com.zunza.buythedip.community.entity.Comment;
+import com.zunza.buythedip.community.entity.Post;
+import com.zunza.buythedip.community.exception.CommentNotFoundException;
+import com.zunza.buythedip.community.exception.PostNotFoundException;
+import com.zunza.buythedip.community.repository.comment.CommentRepository;
+import com.zunza.buythedip.community.repository.post.PostRepository;
+import com.zunza.buythedip.user.entity.User;
+import com.zunza.buythedip.user.exception.UserNotFoundException;
+import com.zunza.buythedip.user.repository.UserRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+	private final UserRepository userRepository;
+	private final PostRepository postRepository;
+	private final CommentRepository commentRepository;
+
+	public void createComment(Long userId, Long postId, CreateCommentDto createCommentDto) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new UserNotFoundException(userId));
+
+		Post post = postRepository.findById(postId)
+			.orElseThrow(() -> new PostNotFoundException(postId));
+
+		commentRepository.save(Comment.createComment(createCommentDto.getContent(), user, post));
+	}
+
+	public void createReply(Long userId, Long postId, Long commentId, CreateReplyDto createReplyDto) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new UserNotFoundException(userId));
+
+		Post post = postRepository.findById(postId)
+			.orElseThrow(() -> new PostNotFoundException(postId));
+
+		Comment comment = commentRepository.findById(commentId)
+			.orElseThrow(() -> new CommentNotFoundException(commentId));
+
+		commentRepository.save(Comment.createReply(createReplyDto.getContent(), user, post, comment));
+	}
+
+	@Transactional
+	public void modifyComment(Long userId, Long commentId, ModifyCommentRequestDto modifyCommentRequestDto) {
+		Comment comment = commentRepository.findByIdAndAuthorId(commentId, userId)
+			.orElseThrow(() -> new CommentNotFoundException(commentId));
+
+		comment.modifyContent(modifyCommentRequestDto);
+	}
+
+	public void deleteComment(Long userId, Long commentId) {
+		Comment comment = commentRepository.findByIdAndAuthorId(commentId, userId)
+			.orElseThrow(() -> new CommentNotFoundException(commentId));
+
+		commentRepository.delete(comment);
+	}
+}


### PR DESCRIPTION
1. 댓글/대댓글 CRUD API 구현 (CommentController)
- 댓글 생성: POST /api/posts/{postId}/comments
- 대댓글 생성: POST /api/posts/{postId}/comments/{commentId}/replies
- 댓글 수정: PATCH /api/comments/{commentId}
- 댓글 삭제: DELETE /api/comments/{commentId}

2. 비즈니스 로직 구현 (CommentService)
- 생성 (createComment, createReply): userId, postId, commentId(대댓글의 경우)가 유효한지 DB에서 먼저 조회하여 데이터의 정합성을 보장
- 수정 (modifyComment): commentRepository.findByIdAndAuthorId()를 사용하여, 댓글을 수정하려는 사용자가 실제 작성자인지 비즈니스 로직 레벨에서 검증
- 삭제 (deleteComment): 수정과 마찬가지로, findByIdAndAuthorId()를 통해 작성자 본인만 댓글을 삭제할 수 있도록 함