### PR TITLE
feat: 게시글 좋아요 API 추가

### DIFF
--- a/src/main/java/com/zunza/buythedip/community/controller/PostLikeController.java
+++ b/src/main/java/com/zunza/buythedip/community/controller/PostLikeController.java
@@ -1,0 +1,37 @@
+package com.zunza.buythedip.community.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.zunza.buythedip.community.service.PostLikeService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class PostLikeController {
+
+	private final PostLikeService postLikeService;
+
+	@PostMapping("/api/posts/{postId}/likes")
+	public ResponseEntity<Void> likePost(
+		@AuthenticationPrincipal Long userId,
+		@PathVariable Long postId
+	) {
+		postLikeService.like(userId, postId);
+		return ResponseEntity.ok().build();
+	}
+
+	@DeleteMapping("/api/posts/{postId}/likes")
+	public ResponseEntity<Void> unlikePost(
+		@AuthenticationPrincipal Long userId,
+		@PathVariable Long postId
+	) {
+		postLikeService.unlike(userId, postId);
+		return ResponseEntity.ok().build();
+	}
+}

--- a/src/main/java/com/zunza/buythedip/community/exception/PostLikeNotFoundException.java
+++ b/src/main/java/com/zunza/buythedip/community/exception/PostLikeNotFoundException.java
@@ -1,0 +1,19 @@
+package com.zunza.buythedip.community.exception;
+
+import com.zunza.buythedip.common.CustomException;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+public class PostLikeNotFoundException extends CustomException {
+
+	private static final String MESSAGE = "해당 게시글에 좋아요를 누르지 않았습니다. POST ID: ";
+
+	public PostLikeNotFoundException(Long postId) {
+		super(MESSAGE + postId);
+	}
+
+	@Override
+	public int getStatusCode() {
+		return HttpServletResponse.SC_NOT_FOUND;
+	}
+}

--- a/src/main/java/com/zunza/buythedip/community/repository/postlike/PostLikeRepository.java
+++ b/src/main/java/com/zunza/buythedip/community/repository/postlike/PostLikeRepository.java
@@ -1,4 +1,4 @@
-package com.zunza.buythedip.community.repository;
+package com.zunza.buythedip.community.repository.postlike;
 
 import java.util.Optional;
 

--- a/src/main/java/com/zunza/buythedip/community/service/PostLikeService.java
+++ b/src/main/java/com/zunza/buythedip/community/service/PostLikeService.java
@@ -1,0 +1,41 @@
+package com.zunza.buythedip.community.service;
+
+import org.springframework.stereotype.Service;
+
+import com.zunza.buythedip.community.entity.Post;
+import com.zunza.buythedip.community.entity.PostLike;
+import com.zunza.buythedip.community.exception.PostLikeNotFoundException;
+import com.zunza.buythedip.community.exception.PostNotFoundException;
+import com.zunza.buythedip.community.repository.postlike.PostLikeRepository;
+import com.zunza.buythedip.community.repository.post.PostRepository;
+import com.zunza.buythedip.user.entity.User;
+import com.zunza.buythedip.user.exception.UserNotFoundException;
+import com.zunza.buythedip.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PostLikeService {
+
+	private final UserRepository userRepository;
+	private final PostRepository postRepository;
+	private final PostLikeRepository postLikeRepository;
+
+	public void like(Long userId, Long postId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new UserNotFoundException(userId));
+
+		Post post = postRepository.findById(postId)
+			.orElseThrow(() -> new PostNotFoundException(postId));
+
+		postLikeRepository.save(PostLike.of(post, user));
+	}
+
+	public void unlike(Long userId, Long postId) {
+		PostLike postLike = postLikeRepository.findByPostIdAndUserId(postId, userId)
+			.orElseThrow(() -> new PostLikeNotFoundException(postId));
+
+		postLikeRepository.delete(postLike);
+	}
+}


### PR DESCRIPTION
1. 좋아요 / 좋아요 취소 API 구현 (PostLikeController)
좋아요: POST /api/posts/{postId}/likes
좋아요 취소: DELETE /api/posts/{postId}/likes

2.비즈니스 로직 구현 (PostLikeService)
like():
- userId와 postId가 유효한지 각각 DB에서 조회하여 검증
- PostLike 엔티티를 생성하고 저장

unlike():
- postLikeRepository.findByPostIdAndUserId()를 사용하여, 좋아요를 취소하려는 사용자가 이전에 눌렀던 좋아요 기록이 실제로 존재하는지 먼저 확인
- 존재하지 않을 경우 PostLikeNotFoundException을 발생시켜 잘못된 요청을 처리
- 존재할 경우, 해당 PostLike 엔티티를 삭제