### PR TITLE
feat: OAuth2를 이용한 소셜 로그인 기능 구현(구글, 네이버, 카카오)

### DIFF
--- a/src/main/kotlin/com/zunza/buythedip/auth/oauth2/CustomOAuth2FailureHandler.kt
+++ b/src/main/kotlin/com/zunza/buythedip/auth/oauth2/CustomOAuth2FailureHandler.kt
@@ -1,0 +1,22 @@
+package com.zunza.buythedip.auth.oauth2
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler
+import org.springframework.stereotype.Component
+import java.net.URLEncoder
+import java.nio.charset.Charset
+
+@Component
+class CustomOAuth2FailureHandler() : SimpleUrlAuthenticationFailureHandler() {
+    override fun onAuthenticationFailure(
+        request: HttpServletRequest?,
+        response: HttpServletResponse?,
+        exception: AuthenticationException?
+    ) {
+        val errorMessage = URLEncoder.encode(exception?.message, Charset.defaultCharset())
+        val redirectionUrl = "http://localhost:5173/login/error?message=$errorMessage"
+        response?.sendRedirect(redirectionUrl)
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip/auth/oauth2/CustomOAuth2SuccessHandler.kt
+++ b/src/main/kotlin/com/zunza/buythedip/auth/oauth2/CustomOAuth2SuccessHandler.kt
@@ -1,0 +1,37 @@
+package com.zunza.buythedip.auth.oauth2
+
+import com.zunza.buythedip.auth.jwt.JwtTokenProvider
+import com.zunza.buythedip.user.repository.RefreshJwtRepository
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.Authentication
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler
+import org.springframework.stereotype.Component
+import java.net.URLEncoder
+import java.nio.charset.Charset
+
+@Component
+class CustomOAuth2SuccessHandler(
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val refreshJwtRepository: RefreshJwtRepository
+) : SimpleUrlAuthenticationSuccessHandler() {
+    override fun onAuthenticationSuccess(
+        request: HttpServletRequest?,
+        response: HttpServletResponse?,
+        authentication: Authentication?
+    ) {
+        val oAuth2User = authentication?.principal as CustomOAuth2User
+
+        val userId = oAuth2User.id
+        val nickname = oAuth2User.name
+
+        val accessJwt = jwtTokenProvider.generateAccessJwt(userId, oAuth2User.authorities)
+        val refreshJwt = jwtTokenProvider.generateRefreshJwt(userId)
+        refreshJwtRepository.save(userId, refreshJwt)
+
+        val encodedNickname = URLEncoder.encode(nickname, Charset.defaultCharset())
+        val redirectionUrl = "http://localhost:5173/login?token=$accessJwt&nickname=$encodedNickname"
+
+        response?.sendRedirect(redirectionUrl)
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip/auth/oauth2/CustomOAuth2User.kt
+++ b/src/main/kotlin/com/zunza/buythedip/auth/oauth2/CustomOAuth2User.kt
@@ -1,0 +1,34 @@
+package com.zunza.buythedip.auth.oauth2
+
+import com.zunza.buythedip.user.entity.User
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.oauth2.core.user.OAuth2User
+
+class CustomOAuth2User(
+    private val user: User
+) : OAuth2User {
+
+    companion object {
+        fun createOf(user: User): CustomOAuth2User {
+            return CustomOAuth2User(user)
+        }
+    }
+
+    override fun getAttributes(): Map<String?, Any?>? {
+        return mapOf()
+    }
+
+    override fun getAuthorities(): Collection<GrantedAuthority?>? {
+        return listOf(GrantedAuthority { user.role.value })
+    }
+
+    override fun getName(): String? {
+        return user.nickname
+    }
+
+    val email: String
+        get() = user.email
+
+    val id: Long
+        get() = user.id
+}

--- a/src/main/kotlin/com/zunza/buythedip/auth/oauth2/CustomOAuth2UserService.kt
+++ b/src/main/kotlin/com/zunza/buythedip/auth/oauth2/CustomOAuth2UserService.kt
@@ -1,0 +1,64 @@
+package com.zunza.buythedip.auth.oauth2
+
+import com.zunza.buythedip.auth.oauth2.dto.GoogleOAuth2Response
+import com.zunza.buythedip.auth.oauth2.dto.KakaoOAuth2Response
+import com.zunza.buythedip.auth.oauth2.dto.NaverOAuth2Response
+import com.zunza.buythedip.auth.oauth2.dto.OAuth2Response
+import com.zunza.buythedip.auth.oauth2.exception.DuplicateEmailWithDifferentProviderException
+import com.zunza.buythedip.auth.oauth2.exception.SocialEmailAlreadyRegisteredException
+import com.zunza.buythedip.user.constant.UserType
+import com.zunza.buythedip.user.entity.User
+import com.zunza.buythedip.user.repository.UserRepository
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest
+import org.springframework.security.oauth2.core.user.OAuth2User
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class CustomOAuth2UserService(
+    private val userRepository: UserRepository
+) : DefaultOAuth2UserService() {
+
+    override fun loadUser(userRequest: OAuth2UserRequest?): OAuth2User? {
+        val oAuth2User = super.loadUser(userRequest)
+        val provider = userRequest?.clientRegistration?.registrationId
+        val oAuth2Response = getOAuth2Response(oAuth2User, provider)
+
+        return userRepository.findByEmail(oAuth2Response.getEmail())
+            ?.let { user ->
+                validateExistingUserForOAuth2Login(user, oAuth2Response)
+                CustomOAuth2User.createOf(user)
+            }
+            ?: run {
+                val user = User.createSocialUser(oAuth2Response, createRandomNickname())
+                val savedUser = userRepository.save(user)
+                CustomOAuth2User.createOf(savedUser)
+            }
+    }
+
+    private fun getOAuth2Response(
+        oAuth2User: OAuth2User,
+        provider: String?
+    ): OAuth2Response {
+        return when (provider) {
+            "google" -> GoogleOAuth2Response(oAuth2User.attributes)
+            "kakao" -> KakaoOAuth2Response(oAuth2User.attributes)
+            "naver" -> NaverOAuth2Response(oAuth2User.attributes)
+            else -> throw IllegalArgumentException("지원하지 않는 Provider 입니다.")
+        }
+    }
+
+    private fun validateExistingUserForOAuth2Login(user: User, oAuth2Response: OAuth2Response) {
+        when {
+            user.type == UserType.NORMAL ->
+                throw SocialEmailAlreadyRegisteredException()
+            user.provider != oAuth2Response.getProvider() ->
+                throw DuplicateEmailWithDifferentProviderException()
+        }
+    }
+
+    private fun createRandomNickname(): String {
+        return "user${UUID.randomUUID().toString().substring(0, 8)}"
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip/auth/oauth2/dto/GoogleOAuth2Response.kt
+++ b/src/main/kotlin/com/zunza/buythedip/auth/oauth2/dto/GoogleOAuth2Response.kt
@@ -1,0 +1,20 @@
+package com.zunza.buythedip.auth.oauth2.dto
+
+import com.zunza.buythedip.user.constant.OAuth2Provider
+
+class GoogleOAuth2Response(
+    private val attribute: Map<String, Any>
+) : OAuth2Response {
+
+    override fun getProvider(): OAuth2Provider {
+        return OAuth2Provider.GOOGLE
+    }
+
+    override fun getProviderId(): String {
+        return attribute["sub"].toString()
+    }
+
+    override fun getEmail(): String {
+        return attribute["email"].toString()
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip/auth/oauth2/dto/KakaoOAuth2Response.kt
+++ b/src/main/kotlin/com/zunza/buythedip/auth/oauth2/dto/KakaoOAuth2Response.kt
@@ -1,0 +1,21 @@
+package com.zunza.buythedip.auth.oauth2.dto
+
+import com.zunza.buythedip.user.constant.OAuth2Provider
+
+class KakaoOAuth2Response(
+    private val attribute: Map<String, Any>
+) : OAuth2Response {
+
+    override fun getProvider(): OAuth2Provider {
+        return OAuth2Provider.KAKAO
+    }
+
+    override fun getProviderId(): String {
+        return attribute["id"].toString()
+    }
+
+    override fun getEmail(): String {
+        val kakaoAccount: Map<String, Any> = attribute["kakao_account"] as Map<String, Any>
+        return kakaoAccount["email"].toString()
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip/auth/oauth2/dto/NaverOAuth2Response.kt
+++ b/src/main/kotlin/com/zunza/buythedip/auth/oauth2/dto/NaverOAuth2Response.kt
@@ -1,0 +1,22 @@
+package com.zunza.buythedip.auth.oauth2.dto
+
+import com.zunza.buythedip.user.constant.OAuth2Provider
+
+class NaverOAuth2Response(
+    private val attribute: Map<String, Any>
+) : OAuth2Response {
+
+    private val response = attribute["response"] as Map<String, Any>
+
+    override fun getProvider(): OAuth2Provider {
+        return OAuth2Provider.NAVER
+    }
+
+    override fun getProviderId(): String {
+        return response["id"].toString()
+    }
+
+    override fun getEmail(): String {
+        return response["email"].toString()
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip/auth/oauth2/dto/OAuth2Response.kt
+++ b/src/main/kotlin/com/zunza/buythedip/auth/oauth2/dto/OAuth2Response.kt
@@ -1,0 +1,9 @@
+package com.zunza.buythedip.auth.oauth2.dto
+
+import com.zunza.buythedip.user.constant.OAuth2Provider
+
+interface OAuth2Response {
+    fun getProvider(): OAuth2Provider;
+    fun getProviderId(): String;
+    fun getEmail(): String
+}

--- a/src/main/kotlin/com/zunza/buythedip/auth/oauth2/exception/DuplicateEmailWithDifferentProviderException.kt
+++ b/src/main/kotlin/com/zunza/buythedip/auth/oauth2/exception/DuplicateEmailWithDifferentProviderException.kt
@@ -1,0 +1,9 @@
+package com.zunza.buythedip.auth.oauth2.exception
+
+import org.springframework.security.core.AuthenticationException
+
+class DuplicateEmailWithDifferentProviderException() : AuthenticationException(MESSAGE) {
+    companion object {
+        private const val MESSAGE = "이미 가입된 이메일입니다."
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip/auth/oauth2/exception/SocialEmailAlreadyRegisteredException.kt
+++ b/src/main/kotlin/com/zunza/buythedip/auth/oauth2/exception/SocialEmailAlreadyRegisteredException.kt
@@ -1,0 +1,9 @@
+package com.zunza.buythedip.auth.oauth2.exception
+
+import org.springframework.security.core.AuthenticationException
+
+class SocialEmailAlreadyRegisteredException() : AuthenticationException(MESSAGE) {
+    companion object {
+        private const val MESSAGE = "이메일이 기존 계정과 연결되어 있습니다."
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/zunza/buythedip/config/SecurityConfig.kt
@@ -4,24 +4,33 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.zunza.buythedip.auth.jwt.JwtAuthenticationFilter
 import com.zunza.buythedip.auth.jwt.JwtExceptionFilter
 import com.zunza.buythedip.auth.jwt.JwtTokenProvider
+import com.zunza.buythedip.auth.oauth2.CustomOAuth2FailureHandler
+import com.zunza.buythedip.auth.oauth2.CustomOAuth2SuccessHandler
+import com.zunza.buythedip.auth.oauth2.CustomOAuth2UserService
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.builders.WebSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
+
 @Configuration
 @EnableWebSecurity
 class SecurityConfig(
     private val authenticationConfiguration: AuthenticationConfiguration,
     private val jwtTokenProvider: JwtTokenProvider,
-    private val objectMapper: ObjectMapper
+    private val objectMapper: ObjectMapper,
+    private val customOAuth2UserService: CustomOAuth2UserService,
+    private val customOAuth2SuccessHandler: CustomOAuth2SuccessHandler,
+    private val customOAuth2FailureHandler: CustomOAuth2FailureHandler
 ) {
     @Bean
     fun passwordEncoder(): PasswordEncoder =
@@ -30,6 +39,14 @@ class SecurityConfig(
     @Bean
     fun authenticationManager(): AuthenticationManager =
         authenticationConfiguration.authenticationManager
+
+    @Bean
+    fun webSecurityCustomizer(): WebSecurityCustomizer =
+        WebSecurityCustomizer { web: WebSecurity? ->
+            web!!.ignoring()
+                .requestMatchers("/error", "/favicon.ico")
+
+    }
 
     @Bean
     fun securityFilterChain(
@@ -42,6 +59,14 @@ class SecurityConfig(
             .logout { it.disable() }
             .sessionManagement {
                 it.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            }
+
+            .oauth2Login { oAuth2 -> oAuth2
+                .userInfoEndpoint { config ->
+                    config.userService(customOAuth2UserService)
+                }
+                .successHandler(customOAuth2SuccessHandler)
+                .failureHandler(customOAuth2FailureHandler)
             }
 
             .authorizeHttpRequests { authorize ->


### PR DESCRIPTION
기존의 이메일 회원가입/로그인 방식에 더하여, 사용자가 Google, Kakao, Naver 계정을 통해 로그인하고 회원가입할 수 있는 OAuth2 소셜 로그인 기능을 구현했습니다.

1. Spring Security 설정
- .oauth2Login() 설정을 통해 OAuth2 로그인 프로세스를 활성화했습니다.
- 인증 과정의 각 단계를 커스터마이징하기 위해 아래의 핸들러와 서비스를 직접 구현하여 등록했습니다.
  - userInfoEndpoint: customOAuth2UserService
  - successHandler: customOAuth2SuccessHandler
  - failureHandler: customOAuth2FailureHandler

2. CustomOAuth2UserService
- DefaultOAuth2UserService를 확장하여 소셜 로그인 시 사용자 정보를 불러오는 구현했습니다.
- 신규 회원 처리: DB에 존재하지 않는 이메일일 경우, 소셜 플랫폼에서 받은 정보를 바탕으로 User를 생성하고 자동 가입시킵니다. (초기 닉네임은 랜덤 생성)
- 기존 회원 처리: DB에 이메일이 이미 존재하는 경우, 아래와 같은 정책에 따라 로그인 처리를 분기합니다.
  - 일반(NORMAL) 회원으로 가입된 이메일일 경우: SocialEmailAlreadyRegisteredException 발생
  - 다른 소셜 플랫폼으로 가입된 이메일일 경우: DuplicateEmailWithDifferentProviderException 발생

3. OAuth2Response 인터페이스
- Google, Kakao, Naver 등 각기 다른 구조로 사용자 정보를 반환하는 소셜 플랫폼의 응답을 일관되게 처리하기 위해 OAuth2Response 인터페이스를 도입하고 각 Provider별 구현체를 작성했습니다.

4. CustomOAuth2SuccessHandler
- 소셜 인증이 성공적으로 완료되면 호출됩니다.
- 인증된 사용자 정보(CustomOAuth2User)를 바탕으로 자체 JWT(Access Token, Refresh Token)를 생성합니다.
- 생성된 Access Token과 사용자 닉네임을 쿼리 파라미터에 담아 프론트엔드 페이지로 리다이렉트시켜 로그인을 완료합니다.

5. CustomOAuth2FailureHandler
- CustomOAuth2UserService에서 발생시킨 AuthenticationException() 예외를 처리합니다.
- 에러 메시지를 쿼리 파라미터에 담아 프론트엔드의 에러 페이지로 리다이렉트합니다.