### PR TITLE
feat: 회원가입 시 기본 왓치리스트 생성

### DIFF
--- a/src/main/kotlin/com/zunza/buythedip/crypto/repository/CryptoRepository.kt
+++ b/src/main/kotlin/com/zunza/buythedip/crypto/repository/CryptoRepository.kt
@@ -1,0 +1,20 @@
+package com.zunza.buythedip.crypto.repository
+
+import com.zunza.buythedip.crypto.entity.Crypto
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+
+@Repository
+interface CryptoRepository : JpaRepository<Crypto, Long> {
+
+    @Query(
+        """
+        SELECT c
+        FROM Crypto c
+        WHERE c.symbol IN :symbols
+        """
+    )
+    fun findBySymbols(@Param("symbols") symbols: List<String>): List<Crypto>
+}

--- a/src/main/kotlin/com/zunza/buythedip/user/service/AuthService.kt
+++ b/src/main/kotlin/com/zunza/buythedip/user/service/AuthService.kt
@@ -10,7 +10,9 @@ import com.zunza.buythedip.user.entity.User
 import com.zunza.buythedip.user.exception.LoginFailedException
 import com.zunza.buythedip.user.repository.RefreshJwtRepository
 import com.zunza.buythedip.user.repository.UserRepository
+import com.zunza.buythedip.watchlist.service.WatchlistService
 import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.transaction.Transactional
 import org.springframework.security.authentication.AuthenticationManager
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.Authentication
@@ -26,7 +28,8 @@ class AuthService(
     private val passwordEncoder: PasswordEncoder,
     private val jwtTokenProvider: JwtTokenProvider,
     private val authenticationManager: AuthenticationManager,
-    private val refreshJwtRepository: RefreshJwtRepository
+    private val refreshJwtRepository: RefreshJwtRepository,
+    private val watchlistService: WatchlistService
 ) {
     fun isEmailAvailable(email: String): EmailAvailableResponse {
         validateEmailFormat(email)
@@ -44,13 +47,16 @@ class AuthService(
         }
     }
 
+    @Transactional
     fun signup(signupRequest: SignupRequest) {
         val encodedPassword = passwordEncoder.encode(signupRequest.password)
-        userRepository.save(User.createNormalUser(
+        val savedUser = userRepository.save(User.createNormalUser(
             signupRequest.email,
             encodedPassword,
             signupRequest.nickname
         ))
+
+        watchlistService.createDefaultWatchlist(savedUser)
     }
 
     fun login(loginRequest: LoginRequest): Map<String, String> {

--- a/src/main/kotlin/com/zunza/buythedip/watchlist/service/WatchlistService.kt
+++ b/src/main/kotlin/com/zunza/buythedip/watchlist/service/WatchlistService.kt
@@ -1,0 +1,32 @@
+package com.zunza.buythedip.watchlist.service
+
+import com.zunza.buythedip.crypto.repository.CryptoRepository
+import com.zunza.buythedip.user.entity.User
+import com.zunza.buythedip.watchlist.entity.Watchlist
+import com.zunza.buythedip.watchlist.entity.WatchlistItem
+import com.zunza.buythedip.watchlist.repository.WatchlistRepository
+import jakarta.transaction.Transactional
+
+class WatchlistService(
+    private val watchlistRepository: WatchlistRepository,
+    private val cryptoRepository: CryptoRepository
+) {
+    /**
+     * TODO: findBySymbols 캐시
+     */
+    @Transactional
+    fun createDefaultWatchlist(user: User) {
+        val symbols = listOf("BTC", "ETH", "XRP", "BNB", "SOL", "DOGE", "TRX", "ADA")
+        val cryptos = cryptoRepository.findBySymbols(symbols)
+        val cryptoMap = cryptos.associateBy { it.symbol }
+
+        val watchlist = Watchlist.createDefaultWatchlist(user)
+        val watchlistItems = symbols.mapIndexed { index, symbol ->
+            val crypto = requireNotNull(cryptoMap[symbol])
+            WatchlistItem.createOf(watchlist, crypto, index)
+        }.toTypedArray()
+
+        watchlist.addItems(*watchlistItems)
+        watchlistRepository.save(watchlist)
+    }
+}


### PR DESCRIPTION
사용자가 회원가입을 완료했을 때 서비스의 핵심 기능을 즉시 경험할 수 있도록, 주요 암호화폐 8종이 포함된 기본 Watchlist을 자동으로 생성해주는 기능을 구현했습니다.

#### 1. AuthService

*   기존 회원가입 로직에서 User 엔티티가 성공적으로 저장된 후, watchlistService.createDefaultWatchlist(savedUser)를 호출하는 코드를 추가했습니다.
*   회원 생성과 관심종목 생성이 동일한 트랜잭션 내에서 처리되도록 하여 데이터 정합성을 보장합니다.

#### 2. WatchlistService

*   내부적으로 BTC, ETH, XRP 등 사전 정의된 심볼 목록을 사용하여 CryptoRepository에서 해당 암호화폐 정보를 일괄 조회합니다.
*   조회된 정보를 바탕으로 Watchlist 및 WatchlistItem 엔티티를 생성하고 데이터베이스에 저장합니다.

#### 3. CryptoRepository

*   IN 절을 사용하여 여러 암호화폐 심볼(symbols) 리스트를 한 번의 쿼리로 효율적으로 조회할 수 있는 findBySymbols 메서드를 추가했습니다.