### PR TITLE
feat: Watchlist 목록 조회 구현

### DIFF
--- a/src/main/kotlin/com/zunza/buythedip/watchlist/controller/WatchlistController.kt
+++ b/src/main/kotlin/com/zunza/buythedip/watchlist/controller/WatchlistController.kt
@@ -1,6 +1,9 @@
 package com.zunza.buythedip.watchlist.controller
 
+import com.zunza.buythedip.watchlist.dto.WatchlistResponse
 import com.zunza.buythedip.watchlist.service.WatchlistService
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -8,6 +11,10 @@ import org.springframework.web.bind.annotation.RestController
 class WatchlistController(
     private val watchlistService: WatchlistService
 ) {
-//    @GetMapping("/api/watchlists/default")
-//    fun get()
+    @GetMapping("/api/watchlists")
+    fun getWatchlists(
+        @AuthenticationPrincipal userId: Long?
+    ): ResponseEntity<List<WatchlistResponse>> {
+        return ResponseEntity.ok(watchlistService.getWatchlist(userId))
+    }
 }

--- a/src/main/kotlin/com/zunza/buythedip/watchlist/dto/WatchlistResponse.kt
+++ b/src/main/kotlin/com/zunza/buythedip/watchlist/dto/WatchlistResponse.kt
@@ -1,0 +1,9 @@
+package com.zunza.buythedip.watchlist.dto
+
+data class WatchlistResponse(
+    val id: Long = 0,
+    val name: String = "",
+    val isDefault: Boolean = true,
+    val isSystem: Boolean = true,
+    val sortOrder: Int = 0
+)

--- a/src/main/kotlin/com/zunza/buythedip/watchlist/repository/WatchlistRepository.kt
+++ b/src/main/kotlin/com/zunza/buythedip/watchlist/repository/WatchlistRepository.kt
@@ -1,9 +1,11 @@
 package com.zunza.buythedip.watchlist.repository
 
 import com.zunza.buythedip.watchlist.entity.Watchlist
+import com.zunza.buythedip.watchlist.repository.querydsl.WatchlistQuerydslRepository
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface WatchlistRepository : JpaRepository<Watchlist, Long> {
+interface WatchlistRepository : JpaRepository<Watchlist, Long>, WatchlistQuerydslRepository {
+
 }

--- a/src/main/kotlin/com/zunza/buythedip/watchlist/repository/querydsl/WatchlistQuerydslRepository.kt
+++ b/src/main/kotlin/com/zunza/buythedip/watchlist/repository/querydsl/WatchlistQuerydslRepository.kt
@@ -1,0 +1,7 @@
+package com.zunza.buythedip.watchlist.repository.querydsl
+
+import com.zunza.buythedip.watchlist.dto.WatchlistResponse
+
+interface WatchlistQuerydslRepository {
+    fun findWatchlist(userId: Long?): List<WatchlistResponse>
+}

--- a/src/main/kotlin/com/zunza/buythedip/watchlist/repository/querydsl/WatchlistQuerydslRepositoryImpl.kt
+++ b/src/main/kotlin/com/zunza/buythedip/watchlist/repository/querydsl/WatchlistQuerydslRepositoryImpl.kt
@@ -1,0 +1,35 @@
+package com.zunza.buythedip.watchlist.repository.querydsl
+
+import com.querydsl.core.types.Projections
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.zunza.buythedip.watchlist.dto.WatchlistResponse
+import com.zunza.buythedip.watchlist.entity.QWatchlist
+import org.springframework.stereotype.Component
+
+@Component
+class WatchlistQuerydslRepositoryImpl(
+    private val jpaQueryFactory: JPAQueryFactory
+) : WatchlistQuerydslRepository {
+    override fun findWatchlist(userId: Long?): List<WatchlistResponse> {
+        val watchlist = QWatchlist.watchlist
+        val condition = when (userId) {
+            null -> watchlist.isSystem.isTrue
+            else -> watchlist.user.id.eq(userId)
+        }
+
+        return jpaQueryFactory
+            .select(Projections.constructor(
+                WatchlistResponse::class.java,
+                watchlist.id,
+                watchlist.name,
+                watchlist.isDefault,
+                watchlist.isSystem,
+                watchlist.sortOrder
+                )
+            )
+            .from(watchlist)
+            .where(condition)
+            .orderBy(watchlist.sortOrder.asc())
+            .fetch()
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip/watchlist/service/WatchlistService.kt
+++ b/src/main/kotlin/com/zunza/buythedip/watchlist/service/WatchlistService.kt
@@ -2,6 +2,7 @@ package com.zunza.buythedip.watchlist.service
 
 import com.zunza.buythedip.crypto.repository.CryptoRepository
 import com.zunza.buythedip.user.entity.User
+import com.zunza.buythedip.watchlist.dto.WatchlistResponse
 import com.zunza.buythedip.watchlist.entity.Watchlist
 import com.zunza.buythedip.watchlist.entity.WatchlistItem
 import com.zunza.buythedip.watchlist.repository.WatchlistRepository
@@ -28,5 +29,9 @@ class WatchlistService(
 
         watchlist.addItems(*watchlistItems)
         watchlistRepository.save(watchlist)
+    }
+
+    fun getWatchlist(userId: Long?): List<WatchlistResponse> {
+        return watchlistRepository.findWatchlist(userId)
     }
 }


### PR DESCRIPTION
사용자가 자신의 관심종목 그룹 목록을 조회하거나, 비로그인 상태일 경우 시스템에서 제공하는 기본 관심종목 그룹 목록을 조회할 수 있는 API를 구현했습니다.

#### 1. API 엔드포인트 추가
- @AuthenticationPrincipal을 nullable(Long?)로 설정하여, 로그인/비로그인 상태를 모두 처리할 수 있도록 구현했습니다.

#### 2. 동적 쿼리 로직 구현 (QueryDSL)
- WatchlistRepositoryImpl에 QueryDSL을 사용하여 동적인 WHERE 절을 생성하는 로직을 구현했습니다.
- 로그인 사용자: userId가 존재하는 경우, 해당 사용자의 watchlist만 필터링합니다. (WHERE user_id = :userId)
- 비로그인 사용자: userId가 null인 경우, 시스템 기본 watchlist만 필터링합니다. (WHERE is_system = true)

#### 3. 정렬 순서 적용
- 조회된 관심종목 목록은 sortOrder 필드를 기준으로 오름차순 정렬하여, 의도된 순서대로 클라이언트에 전달되도록 했습니다.