### PR TITLE
feat: 왓치리스트에 포함된 종목 목록 조회 구현

### DIFF
--- a/src/main/kotlin/com/zunza/buythedip/watchlist/controller/WatchlistController.kt
+++ b/src/main/kotlin/com/zunza/buythedip/watchlist/controller/WatchlistController.kt
@@ -1,10 +1,12 @@
 package com.zunza.buythedip.watchlist.controller
 
+import com.zunza.buythedip.watchlist.dto.WatchlistDetailsResponse
 import com.zunza.buythedip.watchlist.dto.WatchlistResponse
 import com.zunza.buythedip.watchlist.service.WatchlistService
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -16,5 +18,12 @@ class WatchlistController(
         @AuthenticationPrincipal userId: Long?
     ): ResponseEntity<List<WatchlistResponse>> {
         return ResponseEntity.ok(watchlistService.getWatchlist(userId))
+    }
+
+    @GetMapping("/api/watchlists/{watchlistId}")
+    fun getWatchlistDetails(
+        @PathVariable watchlistId: Long
+    ): ResponseEntity<List<WatchlistDetailsResponse>> {
+        return ResponseEntity.ok(watchlistService.getWatchlistDetails(watchlistId))
     }
 }

--- a/src/main/kotlin/com/zunza/buythedip/watchlist/dto/WatchlistDetailsResponse.kt
+++ b/src/main/kotlin/com/zunza/buythedip/watchlist/dto/WatchlistDetailsResponse.kt
@@ -1,0 +1,9 @@
+package com.zunza.buythedip.watchlist.dto
+
+data class WatchlistDetailsResponse(
+    val id: Long = 0,
+    val name: String = "",
+    val symbol: String = "",
+    val logo: String = "",
+    val sortOrder: Int = 0
+)

--- a/src/main/kotlin/com/zunza/buythedip/watchlist/entity/Watchlist.kt
+++ b/src/main/kotlin/com/zunza/buythedip/watchlist/entity/Watchlist.kt
@@ -53,6 +53,9 @@ class Watchlist(
     }
 
     fun addItems(vararg watchlistItems: WatchlistItem) {
-        this.watchlistItems.addAll(watchlistItems)
+        watchlistItems.forEach {
+            it.watchlist = this
+            this.watchlistItems.add(it)
+        }
     }
 }

--- a/src/main/kotlin/com/zunza/buythedip/watchlist/entity/WatchlistItem.kt
+++ b/src/main/kotlin/com/zunza/buythedip/watchlist/entity/WatchlistItem.kt
@@ -19,7 +19,7 @@ class WatchlistItem(
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "watchlist_id", nullable = false)
-    val watchlist: Watchlist,
+    var watchlist: Watchlist? = null,
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "crypto_id", nullable = false)

--- a/src/main/kotlin/com/zunza/buythedip/watchlist/repository/WatchlistRepository.kt
+++ b/src/main/kotlin/com/zunza/buythedip/watchlist/repository/WatchlistRepository.kt
@@ -1,11 +1,31 @@
 package com.zunza.buythedip.watchlist.repository
 
+import com.zunza.buythedip.watchlist.dto.WatchlistDetailsResponse
 import com.zunza.buythedip.watchlist.entity.Watchlist
 import com.zunza.buythedip.watchlist.repository.querydsl.WatchlistQuerydslRepository
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 
 @Repository
 interface WatchlistRepository : JpaRepository<Watchlist, Long>, WatchlistQuerydslRepository {
 
+    @Query(
+        """
+            SELECT new com.zunza.buythedip.watchlist.dto.WatchlistDetailsResponse(
+            c.id,
+            c.name,
+            c.symbol,
+            c.logo,
+            wi.sortOrder
+            )
+            FROM Watchlist w
+            JOIN w.watchlistItems wi
+            JOIN wi.crypto c
+            WHERE w.id = :watchlistId
+            ORDER BY wi.sortOrder ASC
+        """
+    )
+    fun findWatchlistDetailsById(@Param("watchlistId") watchlistId: Long): List<WatchlistDetailsResponse>
 }

--- a/src/main/kotlin/com/zunza/buythedip/watchlist/service/WatchlistService.kt
+++ b/src/main/kotlin/com/zunza/buythedip/watchlist/service/WatchlistService.kt
@@ -2,11 +2,12 @@ package com.zunza.buythedip.watchlist.service
 
 import com.zunza.buythedip.crypto.repository.CryptoRepository
 import com.zunza.buythedip.user.entity.User
+import com.zunza.buythedip.watchlist.dto.WatchlistDetailsResponse
 import com.zunza.buythedip.watchlist.dto.WatchlistResponse
 import com.zunza.buythedip.watchlist.entity.Watchlist
 import com.zunza.buythedip.watchlist.entity.WatchlistItem
 import com.zunza.buythedip.watchlist.repository.WatchlistRepository
-import jakarta.transaction.Transactional
+import org.springframework.transaction.annotation.Transactional
 
 class WatchlistService(
     private val watchlistRepository: WatchlistRepository,
@@ -31,7 +32,13 @@ class WatchlistService(
         watchlistRepository.save(watchlist)
     }
 
+    @Transactional(readOnly = true)
     fun getWatchlist(userId: Long?): List<WatchlistResponse> {
         return watchlistRepository.findWatchlist(userId)
+    }
+
+    @Transactional(readOnly = true)
+    fun getWatchlistDetails(watchlistId: Long): List<WatchlistDetailsResponse> {
+        return watchlistRepository.findWatchlistDetailsById(watchlistId)
     }
 }


### PR DESCRIPTION
특정 왓치리스트에 포함된 종목들의 목록을 조회하는 API를 구현했습니다.

#### 1. WatchlistController
- getWatchlistDetails 메서드와 GET /api/watchlists/{watchlistId} 엔드포인트를 추가했습니다.
#### 2. WatchlistService
- 컨트롤러와 리포지토리를 연결하는 getWatchlistDetails 서비스 메서드를 구현했습니다.
#### 3. WatchlistRepository
- JPQL의 생성자 표현식을 사용하여 Watchlist, WatchlistItem, Crypto 엔티티를 조인하고, 조회 결과를 즉시 DTO로 매핑하도록 구현했습니다. 불필요한 엔티티 로딩을 방지하여 성능을 최적화합니다.
- 조회된 암호화폐 목록은 WatchlistItem의 sortOrder에 따라 정렬됩니다.


