### PR TITLE
feat: 회원가입 기능과 회원가입 시 기본 왓치리스트 생성 구현

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/src/main/java/com/zunza/buythedip/infrastructure/event/event/UserRegisteredEvent.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/event/event/UserRegisteredEvent.java
@@ -1,0 +1,22 @@
+package com.zunza.buythedip.infrastructure.event.event;
+
+import com.zunza.buythedip.user.entity.User;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UserRegisteredEvent {
+	private User user;
+
+	@Builder
+	private UserRegisteredEvent(User user) {
+		this.user = user;
+	}
+
+	public static UserRegisteredEvent createFrom(User user) {
+		return UserRegisteredEvent.builder()
+			.user(user)
+			.build();
+	}
+}

--- a/src/main/java/com/zunza/buythedip/infrastructure/event/listener/UserEventListener.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/event/listener/UserEventListener.java
@@ -1,0 +1,22 @@
+package com.zunza.buythedip.infrastructure.event.listener;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.zunza.buythedip.infrastructure.event.event.UserRegisteredEvent;
+import com.zunza.buythedip.watchlist.service.WatchlistService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class UserEventListener {
+	private final WatchlistService watchlistService;
+
+	// @Async("taskExecutor")
+	@TransactionalEventListener
+	public void handleUserRegistered(UserRegisteredEvent event) {
+		watchlistService.createDefaultWatchlist(event.getUser());
+	}
+}

--- a/src/main/java/com/zunza/buythedip/user/controller/AuthController.java
+++ b/src/main/java/com/zunza/buythedip/user/controller/AuthController.java
@@ -1,0 +1,48 @@
+package com.zunza.buythedip.user.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.zunza.buythedip.common.ApiResponse;
+import com.zunza.buythedip.user.dto.EmailAvailableResponse;
+import com.zunza.buythedip.user.dto.NicknameAvailableResponse;
+import com.zunza.buythedip.user.dto.SignupRequest;
+import com.zunza.buythedip.user.service.AuthService;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+	private final AuthService authService;
+
+	@GetMapping("/signup/email/validation")
+	public ResponseEntity<EmailAvailableResponse> checkEmailDuplication(
+		@RequestParam String email
+	) {
+		return ResponseEntity.ok(authService.isEmailAvailable(email));
+	}
+
+	@GetMapping("/signup/nickname/validation")
+	public ResponseEntity<NicknameAvailableResponse> checkNicknameDuplication(
+		@RequestParam String nickname
+	) {
+		return ResponseEntity.ok(authService.isNicknameAvailable(nickname));
+	}
+
+	@PostMapping("/signup")
+	public ResponseEntity<ApiResponse<Void>> signup(
+		@Valid @RequestBody SignupRequest signupRequest
+	) {
+		authService.signup(signupRequest);
+		return ResponseEntity.status(HttpStatus.CREATED.value()).build();
+	}
+}

--- a/src/main/java/com/zunza/buythedip/user/service/AuthService.java
+++ b/src/main/java/com/zunza/buythedip/user/service/AuthService.java
@@ -1,0 +1,51 @@
+package com.zunza.buythedip.user.service;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.zunza.buythedip.infrastructure.event.event.UserRegisteredEvent;
+import com.zunza.buythedip.user.dto.EmailAvailableResponse;
+import com.zunza.buythedip.user.dto.NicknameAvailableResponse;
+import com.zunza.buythedip.user.dto.SignupRequest;
+import com.zunza.buythedip.user.entity.User;
+import com.zunza.buythedip.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+	private final ApplicationEventPublisher eventPublisher;
+
+	public EmailAvailableResponse isEmailAvailable(String email) {
+		if (userRepository.existsByEmail(email)) {
+			return EmailAvailableResponse.createFrom(false);
+		} else {
+			return EmailAvailableResponse.createFrom(true);
+		}
+	}
+
+	public NicknameAvailableResponse isNicknameAvailable(String nickname) {
+		if (userRepository.existsByNickname(nickname)) {
+			return NicknameAvailableResponse.createFrom(false);
+		} else {
+			return NicknameAvailableResponse.createFrom(true);
+		}
+	}
+
+	@Transactional
+	public void signup(SignupRequest signupRequest) {
+		String encodedPassword = passwordEncoder.encode(signupRequest.getPassword());
+		User savedUser = userRepository.save(User.createNormalUser(
+			signupRequest.getEmail(),
+			encodedPassword,
+			signupRequest.getNickname()
+		));
+
+		eventPublisher.publishEvent(UserRegisteredEvent.createFrom(savedUser));
+	}
+}

--- a/src/main/java/com/zunza/buythedip/watchlist/service/WatchlistService.java
+++ b/src/main/java/com/zunza/buythedip/watchlist/service/WatchlistService.java
@@ -1,0 +1,45 @@
+package com.zunza.buythedip.watchlist.service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.zunza.buythedip.crypto.entity.Crypto;
+import com.zunza.buythedip.crypto.repository.CryptoRepository;
+import com.zunza.buythedip.user.entity.User;
+import com.zunza.buythedip.watchlist.entity.Watchlist;
+import com.zunza.buythedip.watchlist.entity.WatchlistItem;
+import com.zunza.buythedip.watchlist.repository.WatchlistRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class WatchlistService {
+	private final WatchlistRepository watchlistRepository;
+	private final CryptoRepository cryptoRepository;
+
+	@Transactional
+	public void createDefaultWatchlist(User user) {
+		List<String> symbols = List.of("BTC", "ETH", "XRP", "BNB", "SOL", "DOGE", "TRX", "ADA");
+		List<Crypto> cryptos = cryptoRepository.findBySymbols(symbols);
+		Map<String, Crypto> cryptoMap = cryptos.stream()
+			.collect(Collectors.toMap(Crypto::getSymbol, crypto -> crypto));
+
+		Watchlist watchlist = Watchlist.createDefaultWatchlist(user);
+		WatchlistItem[] watchlistItems = IntStream.range(0, symbols.size())
+			.mapToObj(i -> {
+				String symbol = symbols.get(i);
+				Crypto crypto = cryptoMap.get(symbol);
+				return WatchlistItem.createOf(crypto, i);
+			})
+			.toArray(WatchlistItem[]::new);
+
+		watchlist.addWatchlistItem(watchlistItems);
+		watchlistRepository.save(watchlist);
+	}
+}


### PR DESCRIPTION
### 개요
신규 사용자가 회원가입을 완료하면, 초기 서비스 경험 향상을 위해 주요 암호화폐 8종이 포함된 기본 왓치리스트를 자동으로 생성해주는 기능을 추가합니다.

### 회원가입 API Endpoint 추가
- POST /signup 요청을 통해 이메일, 비밀번호, 닉네임으로 사용자를 생성합니다.
- 비밀번호는 PasswordEncoder를 통해 해싱하여 저장합니다.

### 왓치리스트 생성을 위한 이벤트 기반 아키텍처 도입
- 회원가입 트랜잭션과 왓치리스트 생성 트랜잭션을 분리하기 위해 Spring ApplicationEvent를 도입했습니다.
- 사용자 생성이 완료되면 UserRegisteredEvent를 발행하여, 회원가입 로직과 왓치리스트 생성 로직 간의 의존성을 제거했습니다.

### 기본 왓치리스트 생성 로직 구현
- UserRegisteredEvent를 리스닝하는 @TransactionalEventListener를 구현했습니다.
- 왓치리스트 생성이 무거운 작업이 아니라고 판단하여 비동기처리는 하지 않았습니다.
- 이벤트 수신 시, 사전에 정의된 8개의 암호화폐 심볼을 조회하여 기본 왓치리스트 생성하고 DB에 저장합니다.