### PR TITLE
feat: JWT 인증/인가 구현

### DIFF
--- a/src/main/java/com/zunza/buythedip/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/zunza/buythedip/auth/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,47 @@
+package com.zunza.buythedip.auth.jwt;
+
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+	private final JwtProvider jwtProvider;
+
+	private static final String AUTHORIZATION_HEADER = "Authorization";
+	private static final String TOKEN_PREFIX = "Bearer ";
+
+	@Override
+	protected void doFilterInternal(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain filterChain
+	) throws ServletException, IOException {
+
+		String authorizationHeader = request.getHeader(AUTHORIZATION_HEADER);
+		String token = extractAccessTokenFromBearerHeader(authorizationHeader);
+
+		if (!token.isBlank() && jwtProvider.validateToken(token)) {
+			Authentication authentication = jwtProvider.getAuthentication(token);
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+		}
+
+		filterChain.doFilter(request ,response);
+	}
+
+	private String extractAccessTokenFromBearerHeader(String header) {
+		return header != null ?
+			header.substring(TOKEN_PREFIX.length())
+			: "";
+	}
+}

--- a/src/main/java/com/zunza/buythedip/auth/jwt/JwtExceptionFilter.java
+++ b/src/main/java/com/zunza/buythedip/auth/jwt/JwtExceptionFilter.java
@@ -1,0 +1,52 @@
+package com.zunza.buythedip.auth.jwt;
+
+import java.io.IOException;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zunza.buythedip.common.ApiResponse;
+import com.zunza.buythedip.common.ErrorResponse;
+
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtExceptionFilter extends OncePerRequestFilter {
+	private final ObjectMapper objectMapper;
+
+	@Override
+	protected void doFilterInternal(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		FilterChain filterChain
+	) throws ServletException, IOException {
+
+		try {
+			filterChain.doFilter(request, response);
+		} catch (JwtException e) {
+			ErrorResponse errorResponse = ErrorResponse.builder()
+				.message(e.getMessage())
+				.build();
+
+			ApiResponse<Object> apiResponse = ApiResponse.builder()
+				.data(errorResponse)
+				.code(HttpStatus.UNAUTHORIZED.value())
+				.build();
+
+			response.setStatus(HttpStatus.UNAUTHORIZED.value());
+			response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+			response.setCharacterEncoding("UTF-8");
+
+			objectMapper.writeValue(response.getWriter(), apiResponse);
+		}
+	}
+}

--- a/src/main/java/com/zunza/buythedip/auth/jwt/JwtProvider.java
+++ b/src/main/java/com/zunza/buythedip/auth/jwt/JwtProvider.java
@@ -1,0 +1,123 @@
+package com.zunza.buythedip.auth.jwt;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class JwtProvider {
+
+	private final long accessTokenExpireTime;
+	private final long refreshTokenExpireTime;
+	private final SecretKey key;
+
+	public JwtProvider(
+		@Value("${jwt.key}") String secretKey,
+		@Value("${jwt.access-token-expire-time}") long accessTokenExpireTime,
+		@Value("${jwt.refresh-token-expire-time}") long refreshTokenExpireTime) {
+
+		this.accessTokenExpireTime = accessTokenExpireTime;
+		this.refreshTokenExpireTime = refreshTokenExpireTime;
+		this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
+	}
+
+	public String generateAccessToken(
+		Long userId,
+		Collection<? extends GrantedAuthority> roles
+	) {
+		List<String> authorities = roles != null ?
+			roles.stream()
+				.map(GrantedAuthority::getAuthority)
+				.toList()
+			: List.of();
+
+		Instant now = Instant.now();
+		Instant expiration = now.plusMillis(accessTokenExpireTime);
+
+		return Jwts.builder()
+			.subject(userId.toString())
+			.claim("auth", authorities)
+			.issuedAt(Date.from(now))
+			.expiration(Date.from(expiration))
+			.signWith(key, Jwts.SIG.HS256)
+			.compact();
+	}
+
+	public String generateRefreshToken(Long userId) {
+		Instant now = Instant.now();
+		Instant expiration = now.plusMillis(refreshTokenExpireTime);
+
+		return Jwts.builder()
+			.subject(userId.toString())
+			.issuedAt(Date.from(now))
+			.expiration(Date.from(expiration))
+			.signWith(key, Jwts.SIG.HS256)
+			.compact();
+	}
+
+	public boolean validateToken(String token) {
+		try {
+			Jwts.parser()
+				.verifyWith(key)
+				.build()
+				.parseSignedClaims(token);
+			return true;
+		} catch (ExpiredJwtException e) {
+			log.warn("JWT가 만료되었습니다: {}", e.getMessage());
+			throw new JwtException("JWT가 만료되었습니다.");
+		} catch (SignatureException e) {
+			log.warn("JWT 서명 검증에 실패했습니다: {}", e.getMessage());
+			throw new JwtException("JWT 서명 검증에 실패했습니다.");
+		} catch (MalformedJwtException e) {
+			log.warn("잘못된 JWT 형식입니다: {}", e.getMessage());
+			throw new JwtException("잘못된 JWT 형식입니다.");
+		} catch (UnsupportedJwtException e) {
+			log.warn("지원되지 않는 JWT입니다: {}", e.getMessage());
+			throw new JwtException("지원되지 않는 JWT입니다.");
+		}
+	}
+
+	public Authentication getAuthentication(String token) {
+		Claims claims = getClaims(token);
+		Long userId = Long.valueOf(claims.getSubject());
+		List<String> authoritiesList = claims.get("auth", List.class);
+
+		Collection<SimpleGrantedAuthority> authorities = authoritiesList != null ?
+			authoritiesList.stream()
+				.map(SimpleGrantedAuthority::new)
+				.collect(Collectors.toList())
+			: List.of();
+
+		return new UsernamePasswordAuthenticationToken(userId, null, authorities);
+	}
+
+	public Claims getClaims(String token) {
+		return Jwts.parser()
+			.verifyWith(key)
+			.build()
+			.parseSignedClaims(token)
+			.getPayload();
+	}
+}

--- a/src/main/java/com/zunza/buythedip/auth/user/CustomUserDetails.java
+++ b/src/main/java/com/zunza/buythedip/auth/user/CustomUserDetails.java
@@ -1,0 +1,59 @@
+package com.zunza.buythedip.auth.user;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.zunza.buythedip.user.entity.User;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+	private final User user;
+
+	public String getNickname() {
+		return user.getNickname();
+	}
+
+	public Long getUserId() {
+		return user.getId();
+	}
+
+	@Override
+	public String getPassword() {
+		return user.getPassword();
+	}
+
+	@Override
+	public String getUsername() {
+		return user.getEmail();
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return List.of();
+	}
+}

--- a/src/main/java/com/zunza/buythedip/auth/user/CustomUserDetailsService.java
+++ b/src/main/java/com/zunza/buythedip/auth/user/CustomUserDetailsService.java
@@ -1,0 +1,26 @@
+package com.zunza.buythedip.auth.user;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+import com.zunza.buythedip.user.entity.User;
+import com.zunza.buythedip.user.exception.UserNotFoundException;
+import com.zunza.buythedip.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+	private final UserRepository userRepository;
+
+	@Override
+	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+		User user = userRepository.findByEmail(username)
+			.orElseThrow(UserNotFoundException::new);
+
+		return new CustomUserDetails(user);
+	}
+}

--- a/src/main/java/com/zunza/buythedip/config/SecurityConfig.java
+++ b/src/main/java/com/zunza/buythedip/config/SecurityConfig.java
@@ -1,0 +1,102 @@
+package com.zunza.buythedip.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.zunza.buythedip.auth.jwt.JwtAuthenticationFilter;
+import com.zunza.buythedip.auth.jwt.JwtExceptionFilter;
+import com.zunza.buythedip.auth.oauth2.CustomOAuth2FailureHandler;
+import com.zunza.buythedip.auth.oauth2.CustomOAuth2SuccessHandler;
+import com.zunza.buythedip.auth.oauth2.CustomOAuth2UserService;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+	private final AuthenticationConfiguration authenticationConfiguration;
+	private final CustomOAuth2UserService customOAuth2UserService;
+	private final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
+	private final CustomOAuth2FailureHandler customOAuth2FailureHandler;
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final JwtExceptionFilter jwtExceptionFilter;
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+	@Bean
+	public AuthenticationManager authenticationManager() throws Exception {
+		return authenticationConfiguration.getAuthenticationManager();
+	}
+
+	@Bean
+	public WebSecurityCustomizer webSecurityCustomizer() {
+		return web -> web.ignoring()
+			.requestMatchers(
+				"/error",
+				"/favicon.ico",
+				"/css/**",
+				"/js/**"
+				// "/actuator/health"
+			);
+	}
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		return http
+			.csrf(AbstractHttpConfigurer::disable)
+			.httpBasic(AbstractHttpConfigurer::disable)
+			.formLogin(AbstractHttpConfigurer::disable)
+			.logout(AbstractHttpConfigurer::disable)
+			.sessionManagement(session ->
+				session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+			)
+
+			.oauth2Login(oauth2 -> oauth2
+				.userInfoEndpoint(userInfo ->
+					userInfo.userService(customOAuth2UserService)
+				)
+				.successHandler(customOAuth2SuccessHandler)
+				.failureHandler(customOAuth2FailureHandler)
+			)
+
+			.authorizeHttpRequests(authorize -> authorize
+				.requestMatchers(HttpMethod.POST, "/api/watchlists/**").authenticated()
+				.requestMatchers(HttpMethod.DELETE, "/api/watchlists/**").authenticated()
+				.anyRequest().permitAll()
+			)
+
+			.addFilterBefore(
+				jwtExceptionFilter,
+				UsernamePasswordAuthenticationFilter.class
+			)
+
+			.addFilterBefore(
+				jwtAuthenticationFilter,
+				UsernamePasswordAuthenticationFilter.class
+			)
+
+			// .exceptionHandling(exception -> exception
+			// 	.authenticationEntryPoint(jwtAuthenticationEntryPoint())
+			// 	.accessDeniedHandler(jwtAccessDeniedHandler())
+			// )
+
+			.build();
+	}
+}

--- a/src/main/java/com/zunza/buythedip/config/WebMvcConfig.java
+++ b/src/main/java/com/zunza/buythedip/config/WebMvcConfig.java
@@ -1,0 +1,16 @@
+package com.zunza.buythedip.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry.addMapping("/**")
+			.allowedOrigins("http://localhost:5173")
+			.allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+			.allowCredentials(true);
+	}
+}


### PR DESCRIPTION
### 개요
JWT 기반의 인증/인가 시스템을 도입했습니다.

### JwtProvider
- application.yml로부터 secretKey, accessTokenExpireTime, refreshTokenExpireTime 값을 주입받아 토큰 정책을 관리합니다.
- 토큰 생성 시 사용자 ID(subject)와 권한 정보(claim)를 포함하며, 검증 시 발생할 수 있는 다양한 예외 처리하고 로깅합니다.

### JwtAuthenticationFilter
- Spring Security의 UsernamePasswordAuthenticationFilter 앞에 위치할 OncePerRequestFilter 기반의 커스텀 필터를 구현했습니다.
- 요청 헤더에서 Bearer 토큰을 추출하고 JwtProvider를 통해 유효성을 검증합니다.
- 토큰이 유효하면 Authentication 객체를 생성하여 SecurityContextHolder에 등록함으로써, 이후의 인가 처리 및 
@AuthenticationPrincipal 사용이 가능하도록 합니다.

### JwtExceptionFilter
- Spring Security 필터 체인에서 JwtAuthenticationFilter보다 앞서 실행되는 예외 처리 전용 필터입니다.
- 인증 과정에서 발생하는 JwtException을 catch하여, 표준화된 ApiResponse 형식의 JSON 에러 응답(401 Unauthorized)을 직접 생성하고 반환합니다.