### PR TITLE
feat: 로그인 구현

### DIFF
--- a/src/main/java/com/zunza/buythedip/user/controller/AuthController.java
+++ b/src/main/java/com/zunza/buythedip/user/controller/AuthController.java
@@ -1,6 +1,11 @@
 package com.zunza.buythedip.user.controller;
 
+import java.time.Duration;
+import java.util.Map;
+
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,6 +16,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.zunza.buythedip.common.ApiResponse;
 import com.zunza.buythedip.user.dto.EmailAvailableResponse;
+import com.zunza.buythedip.user.dto.LoginRequest;
+import com.zunza.buythedip.user.dto.LoginResponse;
 import com.zunza.buythedip.user.dto.NicknameAvailableResponse;
 import com.zunza.buythedip.user.dto.SignupRequest;
 import com.zunza.buythedip.user.service.AuthService;
@@ -44,5 +51,29 @@ public class AuthController {
 	) {
 		authService.signup(signupRequest);
 		return ResponseEntity.status(HttpStatus.CREATED.value()).build();
+	}
+
+	@PostMapping("/login")
+	public ResponseEntity<LoginResponse> login(
+		@RequestBody LoginRequest loginRequest
+	) {
+		Map<String, String> resultMap = authService.login(loginRequest);
+		ResponseCookie responseCooke = createResponseCooke(resultMap.get("refreshToken"), Duration.ofDays(7));
+
+		return ResponseEntity.ok()
+			.header(HttpHeaders.SET_COOKIE, responseCooke.toString())
+			.body(LoginResponse.createOf(resultMap.get("nickname"), resultMap.get("accessToken")));
+	}
+
+	private ResponseCookie createResponseCooke(
+		String value,
+		Duration maxAge
+	) {
+		return ResponseCookie.from("refreshToken", value)
+			.httpOnly(true)
+			.secure(false)
+			.path("/")
+			.maxAge(maxAge)
+			.build();
 	}
 }

--- a/src/main/java/com/zunza/buythedip/user/dto/LoginRequest.java
+++ b/src/main/java/com/zunza/buythedip/user/dto/LoginRequest.java
@@ -1,0 +1,9 @@
+package com.zunza.buythedip.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class LoginRequest {
+	private String email;
+	private String password;
+}

--- a/src/main/java/com/zunza/buythedip/user/dto/LoginResponse.java
+++ b/src/main/java/com/zunza/buythedip/user/dto/LoginResponse.java
@@ -1,0 +1,26 @@
+package com.zunza.buythedip.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class LoginResponse {
+	private String nickname;
+	private String accessToken;
+
+	@Builder
+	private LoginResponse(String nickname, String accessToken) {
+		this.nickname = nickname;
+		this.accessToken = accessToken;
+	}
+
+	public static LoginResponse createOf(
+		String nickname,
+		String accessToken
+	) {
+		return LoginResponse.builder()
+			.nickname(nickname)
+			.accessToken(accessToken)
+			.build();
+	}
+}

--- a/src/main/java/com/zunza/buythedip/user/exception/LoginFailedException.java
+++ b/src/main/java/com/zunza/buythedip/user/exception/LoginFailedException.java
@@ -1,0 +1,18 @@
+package com.zunza.buythedip.user.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.zunza.buythedip.common.CustomException;
+
+public class LoginFailedException extends CustomException {
+	private static final String MESSAGE = "이메일 또는 비밀번호를 확인해 주세요";
+
+	public LoginFailedException() {
+		super(MESSAGE);
+	}
+
+	@Override
+	public int getStatusCode() {
+		return HttpStatus.UNAUTHORIZED.value();
+	}
+}


### PR DESCRIPTION
### 로그인 API
- POST /api/auth/login 요청을 통해 LoginRequest(email, password)를 받아 인증을 처리합니다.
- 인증 성공 후, AuthService로부터 전달받은 accessToken과 nickname은 JSON 본문으로 응답합니다.
- refreshToken은 ResponseCookie로 생성하여 Set-Cookie 헤더를 통해 클라이언트에 전달합니다.

### 인증 및 JWT 발급
- Spring Security의 AuthenticationManager를 활용하여 사용자 인증을 위임합니다.
- 인증 실패 시, AuthenticationException을 catch하여 LoginFailedException을 발생시킵니다.
- 인증이 성공하면, 인증된 사용자의 정보를 기반으로 JwtProvider를 통해 accessToken과 refreshToken을 생성합니다.
- refreshToken을 Redis에 저장합니다.