### PR TITLE
feat: 로그아웃 구현

### DIFF
--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/service/RedisCacheService.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/service/RedisCacheService.java
@@ -13,4 +13,8 @@ public class RedisCacheService {
 	public void set(String key, String value) {
 		redisTemplate.opsForValue().set(key, value);
 	}
+
+	public boolean delete(String key) {
+		return redisTemplate.delete(key);
+	}
 }

--- a/src/main/java/com/zunza/buythedip/user/controller/AuthController.java
+++ b/src/main/java/com/zunza/buythedip/user/controller/AuthController.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -63,6 +64,19 @@ public class AuthController {
 		return ResponseEntity.ok()
 			.header(HttpHeaders.SET_COOKIE, responseCooke.toString())
 			.body(LoginResponse.createOf(resultMap.get("nickname"), resultMap.get("accessToken")));
+	}
+
+	@PostMapping("/logout")
+	public ResponseEntity<ApiResponse<Void>> logout(
+		@AuthenticationPrincipal Long userId
+	) {
+		authService.logout(userId);
+		ResponseCookie responseCooke = createResponseCooke("", Duration.ZERO);
+
+		return ResponseEntity
+			.status(HttpStatus.NO_CONTENT.value())
+			.header(HttpHeaders.SET_COOKIE, responseCooke.toString())
+			.build();
 	}
 
 	private ResponseCookie createResponseCooke(

--- a/src/main/java/com/zunza/buythedip/user/service/AuthService.java
+++ b/src/main/java/com/zunza/buythedip/user/service/AuthService.java
@@ -22,6 +22,7 @@ import com.zunza.buythedip.user.dto.NicknameAvailableResponse;
 import com.zunza.buythedip.user.dto.SignupRequest;
 import com.zunza.buythedip.user.entity.User;
 import com.zunza.buythedip.user.exception.LoginFailedException;
+import com.zunza.buythedip.user.exception.UserNotFoundException;
 import com.zunza.buythedip.user.repository.UserRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -87,6 +88,10 @@ public class AuthService {
 			"accessToken", accessToken,
 			"refreshToken", refreshToken
 		);
+	}
+
+	public void logout(Long userId) {
+		redisCacheService.delete(userId.toString());
 	}
 
 	private void validateEmailFormat(String email) {


### PR DESCRIPTION
### 로그아웃 컨트롤러
- @AuthenticationPrincipal을 통해 현재 인증된 사용자의 userId를 가져옵니다.
- 클라이언트의 Refresh Token 쿠키를 삭제하도록 max-age가 0으로 설정된 ResponseCookie를 생성하여 Set-Cookie 헤더로 전달합니다.

### AuthService
- 전달받은 userId를 key로 사용하여 Redis에 저장된 Refresh Token을 삭제합니다.
- Refresh Token이 탈취되더라도, 더 이상 새로운 Access Token을 발급받는 데 사용할 수 없게 됩니다.