### PR TITLE
feat: OAuth2를 이용한 로그인 구현

### DIFF
--- a/src/main/java/com/zunza/buythedip/auth/oauth2/CustomOAuth2FailureHandler.java
+++ b/src/main/java/com/zunza/buythedip/auth/oauth2/CustomOAuth2FailureHandler.java
@@ -1,0 +1,32 @@
+package com.zunza.buythedip.auth.oauth2;
+
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CustomOAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+	@Override
+	public void onAuthenticationFailure(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		AuthenticationException exception
+	) throws IOException, ServletException {
+		String errorMessage = URLEncoder.encode(exception.getMessage(), Charset.defaultCharset());
+		String redirectUrl = "http://localhost:5173/login/error?message=" + errorMessage;
+
+		response.sendRedirect(redirectUrl);
+	}
+}

--- a/src/main/java/com/zunza/buythedip/auth/oauth2/CustomOAuth2SuccessHandler.java
+++ b/src/main/java/com/zunza/buythedip/auth/oauth2/CustomOAuth2SuccessHandler.java
@@ -1,0 +1,44 @@
+package com.zunza.buythedip.auth.oauth2;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import com.zunza.buythedip.auth.jwt.JwtProvider;
+import com.zunza.buythedip.infrastructure.redis.service.RedisCacheService;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class CustomOAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+	private final JwtProvider jwtProvider;
+	private final RedisCacheService redisCacheService;
+
+	@Override
+	public void onAuthenticationSuccess(
+		HttpServletRequest request,
+		HttpServletResponse response,
+		Authentication authentication
+	) throws IOException, ServletException {
+		CustomOAuth2User oAuth2User = (CustomOAuth2User)authentication.getPrincipal();
+		Long userId = oAuth2User.getUserId();
+		String nickname = oAuth2User.getName();
+
+		String accessToken = jwtProvider.generateAccessToken(userId, oAuth2User.getAuthorities());
+		String refreshToken = jwtProvider.generateRefreshToken(userId);
+		redisCacheService.set(userId.toString(), refreshToken);
+
+		String encodedNickname = URLEncoder.encode(nickname, Charset.defaultCharset());
+		String redirectionUrl = "http://localhost:5173/login?token=" + accessToken + "&nickname=" + encodedNickname;
+
+		response.sendRedirect(redirectionUrl);
+	}
+}

--- a/src/main/java/com/zunza/buythedip/auth/oauth2/CustomOAuth2User.java
+++ b/src/main/java/com/zunza/buythedip/auth/oauth2/CustomOAuth2User.java
@@ -1,0 +1,36 @@
+package com.zunza.buythedip.auth.oauth2;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import com.zunza.buythedip.user.entity.User;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomOAuth2User implements OAuth2User {
+	private final User user;
+
+	@Override
+	public Map<String, Object> getAttributes() {
+		return Map.of();
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return List.of((GrantedAuthority)() -> user.getUserRole().getValue());
+	}
+
+	@Override
+	public String getName() {
+		return user.getNickname();
+	}
+
+	public Long getUserId() {
+		return user.getId();
+	}
+}

--- a/src/main/java/com/zunza/buythedip/auth/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/zunza/buythedip/auth/oauth2/CustomOAuth2UserService.java
@@ -1,0 +1,78 @@
+package com.zunza.buythedip.auth.oauth2;
+
+import java.util.UUID;
+
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import com.zunza.buythedip.auth.oauth2.exception.DuplicateEmailWithDifferentProviderException;
+import com.zunza.buythedip.auth.oauth2.exception.SocialEmailAlreadyRegisteredException;
+import com.zunza.buythedip.auth.oauth2.dto.GoogleOAuth2Response;
+import com.zunza.buythedip.auth.oauth2.dto.KakaoOAuth2Response;
+import com.zunza.buythedip.auth.oauth2.dto.NaverOAuth2Response;
+import com.zunza.buythedip.auth.oauth2.dto.OAuth2Response;
+import com.zunza.buythedip.user.constant.UserType;
+import com.zunza.buythedip.user.entity.User;
+import com.zunza.buythedip.user.repository.UserRepository;
+import com.zunza.buythedip.watchlist.service.WatchlistService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+	private final UserRepository userRepository;
+	private final WatchlistService watchlistService;
+
+	@Override
+	public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+		OAuth2User oAuth2User = super.loadUser(userRequest);
+		String provider = userRequest.getClientRegistration().getRegistrationId();
+		OAuth2Response oAuth2Response = getOAuth2Response(oAuth2User, provider);
+
+		return userRepository.findByEmail(oAuth2Response.getEmail())
+			.map(user -> {
+				validateExistingUserForOAuth2Login(user, oAuth2Response);
+				return new CustomOAuth2User(user);
+			})
+			.orElseGet(() -> {
+				User user = User.createSocialUser(oAuth2Response, createRandomNickname());
+				User savedUser = userRepository.save(user);
+
+				watchlistService.createDefaultWatchlist(savedUser);
+				return new CustomOAuth2User(user);
+			});
+	}
+
+	private OAuth2Response getOAuth2Response(
+		OAuth2User oAuth2User,
+		String provider
+	) {
+		return switch (provider) {
+			case "google" -> new GoogleOAuth2Response(oAuth2User.getAttributes());
+			case "naver" -> new NaverOAuth2Response(oAuth2User.getAttributes());
+			case "kakao" -> new KakaoOAuth2Response(oAuth2User.getAttributes());
+			default -> throw new IllegalArgumentException("지원하지 않는 Provider 입니다.");
+		};
+	}
+
+	private void validateExistingUserForOAuth2Login(
+		User user,
+		OAuth2Response oAuth2Response
+	) {
+		if (user.getUserType() == UserType.NORMAL) {
+			throw new SocialEmailAlreadyRegisteredException();
+		}
+
+		if (user.getOAuth2Provider() != oAuth2Response.getProvider()) {
+			throw new DuplicateEmailWithDifferentProviderException();
+		}
+	}
+
+	private String createRandomNickname() {
+		return "user" + UUID.randomUUID().toString().substring(0, 8);
+	}
+}

--- a/src/main/java/com/zunza/buythedip/auth/oauth2/dto/GoogleOAuth2Response.java
+++ b/src/main/java/com/zunza/buythedip/auth/oauth2/dto/GoogleOAuth2Response.java
@@ -1,0 +1,27 @@
+package com.zunza.buythedip.auth.oauth2.dto;
+
+import java.util.Map;
+
+import com.zunza.buythedip.user.constant.OAuth2Provider;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class GoogleOAuth2Response implements OAuth2Response {
+	private final Map<String, Object> attribute;
+
+	@Override
+	public OAuth2Provider getProvider() {
+		return OAuth2Provider.GOOGLE;
+	}
+
+	@Override
+	public String getProviderId() {
+		return attribute.get("sub").toString();
+	}
+
+	@Override
+	public String getEmail() {
+		return attribute.get("email").toString();
+	}
+}

--- a/src/main/java/com/zunza/buythedip/auth/oauth2/dto/KakaoOAuth2Response.java
+++ b/src/main/java/com/zunza/buythedip/auth/oauth2/dto/KakaoOAuth2Response.java
@@ -1,0 +1,28 @@
+package com.zunza.buythedip.auth.oauth2.dto;
+
+import java.util.Map;
+
+import com.zunza.buythedip.user.constant.OAuth2Provider;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class KakaoOAuth2Response implements OAuth2Response {
+	private final Map<String, Object> attribute;
+
+	@Override
+	public OAuth2Provider getProvider() {
+		return OAuth2Provider.KAKAO;
+	}
+
+	@Override
+	public String getProviderId() {
+		return attribute.get("id").toString();
+	}
+
+	@Override
+	public String getEmail() {
+		Map<String, Object> kakaoAccount = (Map<String, Object>) attribute.get("kakao_account");
+		return attribute.get("email").toString();
+	}
+}

--- a/src/main/java/com/zunza/buythedip/auth/oauth2/dto/NaverOAuth2Response.java
+++ b/src/main/java/com/zunza/buythedip/auth/oauth2/dto/NaverOAuth2Response.java
@@ -1,0 +1,32 @@
+package com.zunza.buythedip.auth.oauth2.dto;
+
+import java.util.Map;
+
+import com.zunza.buythedip.user.constant.OAuth2Provider;
+
+import lombok.RequiredArgsConstructor;
+
+public class NaverOAuth2Response implements OAuth2Response {
+	private final Map<String, Object> response;
+
+	public NaverOAuth2Response(
+		Map<String, Object> attribute
+	) {
+		this.response = (Map<String, Object>) attribute.get("response");
+	}
+
+	@Override
+	public OAuth2Provider getProvider() {
+		return OAuth2Provider.NAVER;
+	}
+
+	@Override
+	public String getProviderId() {
+		return response.get("id").toString();
+	}
+
+	@Override
+	public String getEmail() {
+		return response.get("email").toString();
+	}
+}

--- a/src/main/java/com/zunza/buythedip/auth/oauth2/dto/OAuth2Response.java
+++ b/src/main/java/com/zunza/buythedip/auth/oauth2/dto/OAuth2Response.java
@@ -1,0 +1,9 @@
+package com.zunza.buythedip.auth.oauth2.dto;
+
+import com.zunza.buythedip.user.constant.OAuth2Provider;
+
+public interface OAuth2Response {
+	OAuth2Provider getProvider();
+	String getProviderId();
+	String getEmail();
+}

--- a/src/main/java/com/zunza/buythedip/auth/oauth2/exception/DuplicateEmailWithDifferentProviderException.java
+++ b/src/main/java/com/zunza/buythedip/auth/oauth2/exception/DuplicateEmailWithDifferentProviderException.java
@@ -1,0 +1,11 @@
+package com.zunza.buythedip.auth.oauth2.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class DuplicateEmailWithDifferentProviderException extends AuthenticationException {
+	private static final String MESSAGE = "이미 가입된 이메일입니다.";
+
+	public DuplicateEmailWithDifferentProviderException() {
+		super(MESSAGE);
+	}
+}

--- a/src/main/java/com/zunza/buythedip/auth/oauth2/exception/SocialEmailAlreadyRegisteredException.java
+++ b/src/main/java/com/zunza/buythedip/auth/oauth2/exception/SocialEmailAlreadyRegisteredException.java
@@ -1,0 +1,13 @@
+package com.zunza.buythedip.auth.oauth2.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+import com.zunza.buythedip.common.CustomException;
+
+public class SocialEmailAlreadyRegisteredException extends AuthenticationException {
+	private static final String MESSAGE = "이메일이 기존 계정과 연결되어 있습니다.";
+
+	public SocialEmailAlreadyRegisteredException() {
+		super(MESSAGE);
+	}
+}


### PR DESCRIPTION
### 개요

사용자들이 별도의 회원가입 절차 없이 기존에 사용하던 소셜 계정(Google, Naver, Kakao)을 통해 서비스를 이용할 수 있도록 OAuth2 기반의 소셜 로그인 기능을 추가합니다.

### CustomOAuth2UserService
- Provider별 응답 파싱: GoogleOAuth2Response, NaverOAuth2Response, KakaoOAuth2Response 구현체를 통해 각기 다른 JSON 구조의 사용자 정보를 일관된 OAuth2Response 인터페이스로 처리합니다.
- 신규 사용자 자동 가입: DB에 존재하지 않는 이메일의 경우, 소셜 사용자로 자동 회원가입을 진행합니다.
    - 초기 닉네임은 user + UUID 조합의 임의 값으로 설정됩니다.
    - 신규 가입 시 WatchlistService.createDefaultWatchlist()를 호출하여 기본 왓치리스트를 생성합니다.
- 기존 사용자 로그인 및 계정 충돌 방지:
    - SocialEmailAlreadyRegisteredException: 소셜 로그인에 사용된 이메일이 이미 일반 회원으로 가입된 경우 발생하는 예외입니다.
    - DuplicateEmailWithDifferentProviderException: 특정 이메일이 Google로 가입되어 있는데, Naver로 다시 로그인을 시도하는 경우와 같이 Provider가 일치하지 않을 때 발생하는 예외입니다.

### CustomOAuth2SuccessHandler
- Spring Security로부터 Authentication 객체를 받아 CustomOAuth2User로 캐스팅하여 userId, nickname 등 필요한 정보를 추출합니다.
- JwtProvider를 사용하여 accessToken과 refreshToken을 발급합니다.
- accessToken과 URL 인코딩된 nickname을 쿼리 스트링에 포함하여 프론트엔드 URL로 리다이렉트시킵니다.

### CustomOAuth2FailureHandler
- AuthenticationException의 메시지를 프론트엔드 에러 페이지로 전달하며 리다이렉트합니다.