### PR TITLE
feat: 로그인/비로그인 사용자 왓치리스트 조회 API 구현

### DIFF
--- a/src/main/java/com/zunza/buythedip/watchlist/controller/WatchlistController.java
+++ b/src/main/java/com/zunza/buythedip/watchlist/controller/WatchlistController.java
@@ -1,0 +1,28 @@
+package com.zunza.buythedip.watchlist.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.zunza.buythedip.watchlist.dto.WatchlistResponse;
+import com.zunza.buythedip.watchlist.service.WatchlistService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/watchlists")
+@RequiredArgsConstructor
+public class WatchlistController {
+	private final WatchlistService watchlistService;
+
+	@GetMapping
+	public ResponseEntity<List<WatchlistResponse>> getWatchlists(
+		@AuthenticationPrincipal Long userId
+	) {
+		return ResponseEntity.ok(watchlistService.getWatchlist(userId));
+	}
+}

--- a/src/main/java/com/zunza/buythedip/watchlist/dto/WatchlistResponse.java
+++ b/src/main/java/com/zunza/buythedip/watchlist/dto/WatchlistResponse.java
@@ -1,0 +1,14 @@
+package com.zunza.buythedip.watchlist.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class WatchlistResponse {
+	private Long id;
+	private String name;
+	private boolean isDefault;
+	private boolean isSystem;
+	private int sortOrder;
+}

--- a/src/main/java/com/zunza/buythedip/watchlist/repository/WatchlistRepository.java
+++ b/src/main/java/com/zunza/buythedip/watchlist/repository/WatchlistRepository.java
@@ -1,10 +1,31 @@
 package com.zunza.buythedip.watchlist.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import com.zunza.buythedip.watchlist.dto.WatchlistResponse;
 import com.zunza.buythedip.watchlist.entity.Watchlist;
 
 @Repository
 public interface WatchlistRepository extends JpaRepository<Watchlist, Long> {
+	@Query(
+		"""
+		SELECT new com.zunza.buythedip.watchlist.dto.WatchlistResponse(
+		w.id,
+		w.name,
+		w.isDefault,
+		w.isSystem,
+		w.sortOrder
+		)
+		From Watchlist w
+		WHERE (:userId IS NULL AND w.isSystem = true)
+		OR (:userId IS NOT NULL AND w.user.id = :userId)
+		ORDER By w.sortOrder ASC
+		"""
+	)
+	List<WatchlistResponse> findWatchlistsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/zunza/buythedip/watchlist/service/WatchlistService.java
+++ b/src/main/java/com/zunza/buythedip/watchlist/service/WatchlistService.java
@@ -11,8 +11,11 @@ import org.springframework.transaction.annotation.Transactional;
 import com.zunza.buythedip.crypto.entity.Crypto;
 import com.zunza.buythedip.crypto.repository.CryptoRepository;
 import com.zunza.buythedip.user.entity.User;
+import com.zunza.buythedip.user.repository.UserRepository;
+import com.zunza.buythedip.watchlist.dto.WatchlistResponse;
 import com.zunza.buythedip.watchlist.entity.Watchlist;
 import com.zunza.buythedip.watchlist.entity.WatchlistItem;
+import com.zunza.buythedip.watchlist.repository.WatchlistItemRepository;
 import com.zunza.buythedip.watchlist.repository.WatchlistRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -20,8 +23,10 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class WatchlistService {
+	private final WatchlistItemRepository watchlistItemRepository;
 	private final WatchlistRepository watchlistRepository;
 	private final CryptoRepository cryptoRepository;
+	private final UserRepository userRepository;
 
 	@Transactional
 	public void createDefaultWatchlist(User user) {
@@ -41,5 +46,10 @@ public class WatchlistService {
 
 		watchlist.addWatchlistItem(watchlistItems);
 		watchlistRepository.save(watchlist);
+	}
+
+	@Transactional(readOnly = true)
+	public List<WatchlistResponse> getWatchlist(Long userId) {
+		return watchlistRepository.findWatchlistsByUserId(userId);
 	}
 }


### PR DESCRIPTION
### 개요
인증된 사용자는 자신의 맞춤 왓치리스트를, 비인증 사용자는 서비스에서 제공하는 기본 시스템 왓치리스트를 조회할 수 있는 API를 구현합니다. 

### WatchlistController
- @AuthenticationPrincipal을 사용하여 JWT 토큰에서 인증된 사용자의 userId를 추출합니다. 비인증 사용자의 경우 이 값은 null이 됩니다.

### WatchlistService
- @Transactional(readOnly = true) 어노테이션을 적용하여 Dirty Checking 등 불필요한 오버헤드를 줄이는 읽기 전용 트랜잭션으로 최적화합니다.

### WatchlistRepository
- userId 파라미터의 NULL 여부를 JPQL의 WHERE 절에서 동적으로 판단하여, 인증된 사용자의 목록과 시스템 기본 목록을 하나의 쿼리 메서드로 처리합니다.
- DTO 프로젝션을 사용하여 조회 결과를 즉시 WatchlistResponse DTO로 매핑합니다.