### PR TITLE
feat: 특정 왓치리스트 종목 조회 API 구현

### DIFF
--- a/src/main/java/com/zunza/buythedip/watchlist/controller/WatchlistController.java
+++ b/src/main/java/com/zunza/buythedip/watchlist/controller/WatchlistController.java
@@ -5,9 +5,11 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.zunza.buythedip.watchlist.dto.WatchlistDetailsResponse;
 import com.zunza.buythedip.watchlist.dto.WatchlistResponse;
 import com.zunza.buythedip.watchlist.service.WatchlistService;
 
@@ -24,5 +26,12 @@ public class WatchlistController {
 		@AuthenticationPrincipal Long userId
 	) {
 		return ResponseEntity.ok(watchlistService.getWatchlist(userId));
+	}
+
+	@GetMapping("/{watchlistId}")
+	public ResponseEntity<List<WatchlistDetailsResponse>> getWatchlistDetails(
+		@PathVariable Long watchlistId
+	) {
+		return ResponseEntity.ok(watchlistService.getWatchlistDetails(watchlistId));
 	}
 }

--- a/src/main/java/com/zunza/buythedip/watchlist/dto/WatchlistDetailsResponse.java
+++ b/src/main/java/com/zunza/buythedip/watchlist/dto/WatchlistDetailsResponse.java
@@ -1,0 +1,15 @@
+package com.zunza.buythedip.watchlist.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class WatchlistDetailsResponse {
+	private Long watchlistItemId;
+	private Long cryptoId;
+	private String name;
+	private String symbol;
+	private String logo;
+	private int sortOrder;
+}

--- a/src/main/java/com/zunza/buythedip/watchlist/repository/WatchlistRepository.java
+++ b/src/main/java/com/zunza/buythedip/watchlist/repository/WatchlistRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import com.zunza.buythedip.watchlist.dto.WatchlistDetailsResponse;
 import com.zunza.buythedip.watchlist.dto.WatchlistResponse;
 import com.zunza.buythedip.watchlist.entity.Watchlist;
 
@@ -28,4 +29,23 @@ public interface WatchlistRepository extends JpaRepository<Watchlist, Long> {
 		"""
 	)
 	List<WatchlistResponse> findWatchlistsByUserId(@Param("userId") Long userId);
+
+	@Query(
+		"""
+		SELECT new com.zunza.buythedip.watchlist.dto.WatchlistDetailsResponse
+		wi.id,
+		c.id,
+		c.name,
+		c.symbol,
+		c.logo,
+		wi.sortOrder
+		)
+		FROM Watchlist w
+		JOIN w.watchlistItems wi
+		JOIN wi.crypto c
+		WHERE w.id = :watchlistId
+		ORDER BY wi.sortOrder ASC
+		"""
+	)
+	List<WatchlistDetailsResponse> findWatchlistDetailsById(Long watchlistId);
 }

--- a/src/main/java/com/zunza/buythedip/watchlist/service/WatchlistService.java
+++ b/src/main/java/com/zunza/buythedip/watchlist/service/WatchlistService.java
@@ -12,6 +12,7 @@ import com.zunza.buythedip.crypto.entity.Crypto;
 import com.zunza.buythedip.crypto.repository.CryptoRepository;
 import com.zunza.buythedip.user.entity.User;
 import com.zunza.buythedip.user.repository.UserRepository;
+import com.zunza.buythedip.watchlist.dto.WatchlistDetailsResponse;
 import com.zunza.buythedip.watchlist.dto.WatchlistResponse;
 import com.zunza.buythedip.watchlist.entity.Watchlist;
 import com.zunza.buythedip.watchlist.entity.WatchlistItem;
@@ -51,5 +52,10 @@ public class WatchlistService {
 	@Transactional(readOnly = true)
 	public List<WatchlistResponse> getWatchlist(Long userId) {
 		return watchlistRepository.findWatchlistsByUserId(userId);
+	}
+
+	@Transactional(readOnly = true)
+	public List<WatchlistDetailsResponse> getWatchlistDetails(Long watchlistId) {
+		return watchlistRepository.findWatchlistDetailsById(watchlistId);
 	}
 }


### PR DESCRIPTION
### 개요

사용자가 자신의 왓치리스트 중 하나를 선택했을 때, 그 안에 포함된 암호화폐들의 정보(이름, 심볼, 로고 등) 리스트를 제공하는 API를 구현했습니다.

### WatchlistController
- @PathVariable을 통해 조회하고자 하는 관심목록의 id를 전달받습니다.

### WatchlistRepository
- Watchlist, WatchlistItem, Crypto 세 개의 엔티티를 JOIN하여, 각 관심목록 항목에 대한 암호화폐 정보를 한 번의 쿼리로 조회합니다.
- DTO 프로젝션을 적용했습니다.