### PR TITLE
feat: 암호화폐 일일 시가 캐싱 스케줄러 구현

### DIFF
--- a/src/main/java/com/zunza/buythedip/crypto/scheduler/CryptoScheduler.java
+++ b/src/main/java/com/zunza/buythedip/crypto/scheduler/CryptoScheduler.java
@@ -1,0 +1,72 @@
+package com.zunza.buythedip.crypto.scheduler;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.zunza.buythedip.crypto.repository.CryptoRepository;
+import com.zunza.buythedip.external.binance.client.BinanceClient;
+import com.zunza.buythedip.infrastructure.redis.constant.RedisKey;
+import com.zunza.buythedip.infrastructure.redis.service.RedisReactiveCacheService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CryptoScheduler {
+	private final BinanceClient binanceClient;
+	private final CryptoRepository cryptoRepository;
+	private final RedisReactiveCacheService reactiveCacheService;
+
+	private static final String SYMBOL_SUFFIX = "USDT";
+
+	@Scheduled(cron = "3 0 0 * * *", zone = "UTC")
+	public void cacheDailyOpenPrice() {
+		long startTime = System.currentTimeMillis();
+		log.info("open price 캐싱 작업을 시작합니다.");
+
+		Mono<List<String>> symbolsMono = Mono.fromCallable(() ->
+			cryptoRepository.findAll().stream()
+				.map(crypto -> crypto.getSymbol() + SYMBOL_SUFFIX)
+				.toList()
+		);
+
+		symbolsMono
+			.subscribeOn(Schedulers.boundedElastic())
+			.flatMapMany(Flux::fromIterable)
+			.flatMap(this::cacheSymbolOpenPrice)
+			.doFinally(signalType -> {
+				long endTime = System.currentTimeMillis();
+				log.info("open price 캐싱 작업이 최종적으로 완료되었습니다. (총 소요 시간: {}ms) [종료 타입: {}]",
+					endTime - startTime, signalType);
+			})
+			.subscribe();
+	}
+
+	private Mono<Void> cacheSymbolOpenPrice(String symbol) {
+		return binanceClient.getKline(symbol, "1d", 1)
+			.flatMap(klines -> {
+				BigDecimal openPrice = klines.get(0).getOpen();
+				String key = RedisKey.OPEN_PRICE_KEY_PREFIX.getValue() + symbol;
+
+				return reactiveCacheService.set(key, openPrice.toPlainString())
+					.doOnSuccess(result -> {
+							if (result) log.debug("[캐싱 성공] [symbol]: {} | [open price]: {}", symbol, openPrice);
+							else log.warn("[캐싱 실패] [symbol]: {}", symbol);
+						});
+			})
+			.onErrorResume(error -> {
+					log.warn("[API 요청 실패] [symbol]: {} | [에러]: {}", symbol, error.getMessage());
+					return Mono.empty();
+				}
+			)
+			.then();
+	}
+}

--- a/src/main/java/com/zunza/buythedip/external/binance/client/BinanceClient.java
+++ b/src/main/java/com/zunza/buythedip/external/binance/client/BinanceClient.java
@@ -1,0 +1,46 @@
+package com.zunza.buythedip.external.binance.client;
+
+import java.util.List;
+
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.zunza.buythedip.external.binance.dto.KlineRestApiResponse;
+
+import reactor.core.publisher.Mono;
+
+@Component
+public class BinanceClient {
+
+	private static final String BASE_URL = "https://data-api.binance.vision";
+
+	private final WebClient webClient;
+
+	public BinanceClient(WebClient.Builder webClientBuilder) {
+		this.webClient = webClientBuilder
+			.defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+			.baseUrl(BASE_URL)
+			// .codecs(config -> config
+			// 	.defaultCodecs()
+			// 	.maxInMemorySize(19 * 1024 * 1024)
+			// )
+			.build();
+	}
+
+	public Mono<List<KlineRestApiResponse>> getKline(String symbol, String interval, int limit) {
+		return webClient.get()
+			.uri(uriBuilder -> uriBuilder
+				.path("/api/v3/klines")
+				.queryParam("symbol", symbol)
+				.queryParam("interval", interval)
+				.queryParam("limit", limit)
+				.build()
+			)
+			.retrieve()
+			.bodyToMono(new ParameterizedTypeReference<>() {
+			});
+	}
+}

--- a/src/main/java/com/zunza/buythedip/external/binance/dto/KlineRestApiResponse.java
+++ b/src/main/java/com/zunza/buythedip/external/binance/dto/KlineRestApiResponse.java
@@ -1,0 +1,27 @@
+package com.zunza.buythedip.external.binance.dto;
+
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.zunza.buythedip.external.binance.dto.deserializer.KlineDeserializer;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonDeserialize(using = KlineDeserializer.class)
+public class KlineRestApiResponse {
+	private Long openTime;
+	private BigDecimal open;
+	private BigDecimal high;
+	private BigDecimal low;
+	private BigDecimal close;
+	private BigDecimal volume;
+	private Long closeTime;
+	private BigDecimal quoteAssetVolume;
+	private Long numberOfTrades;
+	private BigDecimal takerBuyBaseVolume;
+	private BigDecimal takerBuyQuoteVolume;
+	private BigDecimal ignore;
+}

--- a/src/main/java/com/zunza/buythedip/external/binance/dto/deserializer/KlineDeserializer.java
+++ b/src/main/java/com/zunza/buythedip/external/binance/dto/deserializer/KlineDeserializer.java
@@ -1,0 +1,35 @@
+package com.zunza.buythedip.external.binance.dto.deserializer;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.zunza.buythedip.external.binance.dto.KlineRestApiResponse;
+
+public class KlineDeserializer extends JsonDeserializer<KlineRestApiResponse> {
+
+	@Override
+	public KlineRestApiResponse deserialize(
+		JsonParser p,
+		DeserializationContext ctxt
+	) throws IOException {
+		Object[] node = p.readValueAs(Object[].class);
+
+		return new KlineRestApiResponse(
+			((Number) node[0]).longValue(),
+			new BigDecimal((String) node[1]),
+			new BigDecimal((String) node[2]),
+			new BigDecimal((String) node[3]),
+			new BigDecimal((String) node[4]),
+			new BigDecimal((String) node[5]),
+			((Number) node[6]).longValue(),
+			new BigDecimal((String) node[7]),
+			((Number) node[8]).longValue(),
+			new BigDecimal((String) node[9]),
+			new BigDecimal((String) node[10]),
+			new BigDecimal((String) node[11])
+		);
+	}
+}

--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/constant/RedisKey.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/constant/RedisKey.java
@@ -1,0 +1,15 @@
+package com.zunza.buythedip.infrastructure.redis.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum RedisKey {
+	OPEN_PRICE_KEY_PREFIX("OPEN:PRICE:"),
+	TICK_SIZE_KEY_PREFIX("TICK:SIZE:");
+
+	private String value;
+
+	RedisKey(String value) {
+		this.value = value;
+	}
+}

--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/service/RedisReactiveCacheService.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/service/RedisReactiveCacheService.java
@@ -1,0 +1,17 @@
+package com.zunza.buythedip.infrastructure.redis.service;
+
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@Service
+@RequiredArgsConstructor
+public class RedisReactiveCacheService {
+	private final ReactiveStringRedisTemplate redisTemplate;
+
+	public Mono<Boolean> set(String key, String value) {
+		return redisTemplate.opsForValue().set(key, value);
+	}
+}


### PR DESCRIPTION
#### BinanceClient 구현
- Spring WebClient를 사용하여 Binance API와 통신하는 리액티브 HTTP 클라이언트를 구현했습니다.
- klines (캔들스틱 데이터) 엔드포인트를 호출하여 특정 심볼의 일봉 데이터를 가져오는 getKline 메서드를 구현했습니다.

#### CryptoScheduler 구현
- @Scheduled를 이용한 주기적 실행: cron = "3 0 0 * * *" 설정을 통해 매일 UTC 0시 0분 3초에 cacheDailyOpenPrice 메서드가 실행되도록 설정했습니다.
- cryptoRepository.findAll()은 Blocking I/O이므로, Mono.fromCallable과 subscribeOn(Schedulers.boundedElastic())을 조합하여 별도의 스레드 풀에서 실행되도록 했니다.
- flatMapMany로 심볼 리스트를 개별 스트림으로 변환한 뒤, flatMap을 통해 각 심볼에 대한 API 요청 및 캐싱 작업을 병렬로 동시 실행합니다. 이를 통해 전체 작업 시간을 크게 단축시켰습니다.
- cacheSymbolOpenPrice 내부의 onErrorResume 연산자는 binanceClient의 API 호출이 실패하더라도 Mono.empty()를 반환하여 스트림을 정상적으로 계속 진행시킵니다. 따라서 하나의 실패가 전체 스케줄러를 중단시키지 않습니다.