### PR TITLE
feat: Binance WebSocket을 활용한 실시간 암호화폐 시세 스트리밍 구현

### DIFF
--- a/src/main/java/com/zunza/buythedip/external/binance/dto/SubscribeRequest.java
+++ b/src/main/java/com/zunza/buythedip/external/binance/dto/SubscribeRequest.java
@@ -1,0 +1,14 @@
+package com.zunza.buythedip.external.binance.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SubscribeRequest {
+	private String method;
+	private List<String> params;
+	private String id;
+}

--- a/src/main/java/com/zunza/buythedip/external/binance/dto/TickerData.java
+++ b/src/main/java/com/zunza/buythedip/external/binance/dto/TickerData.java
@@ -1,0 +1,18 @@
+package com.zunza.buythedip.external.binance.dto;
+
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TickerData {
+	@JsonProperty("s")
+	private String symbol;
+
+	@JsonProperty("c")
+	private BigDecimal closePrice;
+}

--- a/src/main/java/com/zunza/buythedip/external/binance/dto/TickerStreamResponse.java
+++ b/src/main/java/com/zunza/buythedip/external/binance/dto/TickerStreamResponse.java
@@ -1,0 +1,11 @@
+package com.zunza.buythedip.external.binance.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TickerStreamResponse {
+	private TickerData data;
+}

--- a/src/main/java/com/zunza/buythedip/external/binance/stream/handler/TickerStreamHandler.java
+++ b/src/main/java/com/zunza/buythedip/external/binance/stream/handler/TickerStreamHandler.java
@@ -1,0 +1,55 @@
+package com.zunza.buythedip.external.binance.stream.handler;
+
+import java.util.List;
+
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zunza.buythedip.crypto.service.CryptoService;
+import com.zunza.buythedip.external.binance.dto.SubscribeRequest;
+import com.zunza.buythedip.external.binance.dto.TickerStreamResponse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class TickerStreamHandler extends TextWebSocketHandler {
+	private final List<String> symbols;
+	private final int chunkSize;
+	private final ObjectMapper objectMapper;
+	private final CryptoService cryptoService;
+
+	@Override
+	public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+		for (int i = 0; i < symbols.size(); i += chunkSize) {
+			List<String> chunk = symbols.subList(i, Math.min(i + chunkSize, symbols.size()));
+
+			SubscribeRequest payloadObj = new SubscribeRequest(
+				"SUBSCRIBE",
+				chunk,
+				String.valueOf((i / chunkSize) + 1)
+			);
+
+			String payload = objectMapper.writeValueAsString(payloadObj);
+			session.sendMessage(new TextMessage(payload));
+			Thread.sleep(200);
+		}
+	}
+
+	@Override
+	protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+		TickerStreamResponse response = objectMapper.readValue(
+			message.getPayload(),
+			TickerStreamResponse.class
+		);
+
+		if (response.getData() == null) {
+			return;
+		}
+
+		cryptoService.publishTicker(response.getData());
+	}
+}

--- a/src/main/java/com/zunza/buythedip/external/binance/stream/manager/TickerStreamManager.java
+++ b/src/main/java/com/zunza/buythedip/external/binance/stream/manager/TickerStreamManager.java
@@ -1,0 +1,51 @@
+package com.zunza.buythedip.external.binance.stream.manager;
+
+import java.util.List;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.client.WebSocketClient;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zunza.buythedip.crypto.repository.CryptoRepository;
+import com.zunza.buythedip.crypto.service.CryptoService;
+import com.zunza.buythedip.external.binance.stream.handler.TickerStreamHandler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TickerStreamManager {
+	private final ObjectMapper objectMapper;
+	private final WebSocketClient webSocketClient;
+	private final CryptoService cryptoService;
+	private final CryptoRepository cryptoRepository;
+
+	private static final String TICKER_STREAM_URL = "wss://data-stream.binance.vision/stream";
+	private static final String TICKER_STREAM_SUFFIX = "usdt@miniTicker";
+	private static final int CHUNK_SIZE = 203;
+
+	@EventListener(ApplicationReadyEvent.class)
+	public void startStreaming() {
+		List<String> symbols = cryptoRepository.findAll().stream()
+			.map(crypto -> crypto.getSymbol().toLowerCase() + TICKER_STREAM_SUFFIX)
+			.toList();
+
+		if (symbols.isEmpty()) {
+			log.warn("심볼이 존재하지 않습니다.");
+			return;
+		}
+
+		TickerStreamHandler handler = new TickerStreamHandler(
+			symbols,
+			CHUNK_SIZE,
+			objectMapper,
+			cryptoService
+		);
+
+		webSocketClient.execute(handler, TICKER_STREAM_URL);
+	}
+}


### PR DESCRIPTION
#### TickerStreamManager
- @EventListener(ApplicationReadyEvent.class)를 사용하여, 애플리케이션의 모든 컴포넌트가 준비된 시점에 WebSocket 연결 프로세스를 시작합니다.
- CryptoRepository를 통해 DB에 저장된 모든 암호화폐 정보를 가져와 Binance 스트림에 맞는 구독 목록(btcusdt@miniTicker, ethusdt@miniTicker 등)을  생성합니다.
- 실제 WebSocket 연결 및 핸들링 로직을 담고 있는 TickerStreamHandler 인스턴스를 생성하고, WebSocketClient를 통해 실행합니다.
#### TickerStreamHandler
- Binance는 단일 커넥션에서 구독할 수 있는 스트림의 개수에 제한이 있습니다. 따라서 전체 심볼 리스트를 203개 단위의 청크로 분할합니다.
- 각 청크에 대한 SUBSCRIBE 요청을 보낸 후 Thread.sleep(200)을 호출하여, 많은 요청으로 인해 API 서버로부터 연결이 거부되는 것을 방지합니다.
- 스트림으로부터 메시지를 수신할 때마다 ObjectMapper를 사용해 TickerStreamResponse DTO로 파싱합니다.
파싱된 데이터는 cryptoService.publishTicker() 메서드로 즉시 전달됩니다. WebSocket 핸들러는 통신에만 집중하고, 데이터 처리 로직은 서비스 레이어에서 담당하도록 역할을 분리했습니다.