### PR TITLE
feat: 실시간 시세 데이터 가공 및 Redis Pub/Sub 발행 구현

### DIFF
--- a/src/main/java/com/zunza/buythedip/crypto/dto/TickerResponse.java
+++ b/src/main/java/com/zunza/buythedip/crypto/dto/TickerResponse.java
@@ -1,0 +1,32 @@
+package com.zunza.buythedip.crypto.dto;
+
+import java.math.BigDecimal;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class TickerResponse {
+	private String symbol;
+	private BigDecimal currentPrice;
+	private BigDecimal changePrice;
+	private BigDecimal changeRate;
+
+	public static TickerResponse createOf(
+		String symbol,
+		BigDecimal currentPrice,
+		BigDecimal changePrice,
+		BigDecimal changeRate
+	) {
+		return TickerResponse.builder()
+			.symbol(symbol)
+			.currentPrice(currentPrice)
+			.changePrice(changePrice)
+			.changeRate(changeRate)
+			.build();
+	}
+}

--- a/src/main/java/com/zunza/buythedip/crypto/service/CryptoService.java
+++ b/src/main/java/com/zunza/buythedip/crypto/service/CryptoService.java
@@ -1,0 +1,70 @@
+package com.zunza.buythedip.crypto.service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import com.zunza.buythedip.crypto.dto.TickerResponse;
+import com.zunza.buythedip.external.binance.dto.TickerData;
+import com.zunza.buythedip.infrastructure.redis.constant.Channels;
+import com.zunza.buythedip.infrastructure.redis.constant.RedisKey;
+import com.zunza.buythedip.infrastructure.redis.pubsub.RedisMessagePublisher;
+import com.zunza.buythedip.infrastructure.redis.service.RedisCacheService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CryptoService {
+	private final RedisCacheService redisCacheService;
+	private final RedisMessagePublisher redisMessagePublisher;
+
+	public void publishTicker(TickerData data) {
+		BigDecimal openPrice = getOpenPrice(data.getSymbol());
+		BigDecimal currentPrice = data.getClosePrice();
+		BigDecimal changePrice = currentPrice.subtract(openPrice);
+		BigDecimal changeRate = getChangeRate(openPrice, currentPrice);
+
+		int scale = getScale(data.getSymbol());
+
+		TickerResponse tickerResponse = TickerResponse.createOf(
+			data.getSymbol().replace("USDT", ""),
+			currentPrice.setScale(scale, RoundingMode.HALF_UP),
+			changePrice.setScale(scale, RoundingMode.HALF_UP),
+			changeRate.setScale(2, RoundingMode.HALF_UP)
+		);
+
+		redisMessagePublisher.publishMessage(
+			Channels.TICKER_CHANNEL.getTopic(),
+			tickerResponse
+		);
+	}
+
+	private BigDecimal getChangeRate(BigDecimal openPrice, BigDecimal currentPrice) {
+		if (openPrice.compareTo(BigDecimal.ZERO) == 0) {
+			return BigDecimal.ZERO;
+		}
+
+		return currentPrice.subtract(openPrice)
+			.divide(openPrice, 10, RoundingMode.HALF_UP)
+			.multiply(BigDecimal.valueOf(100));
+	}
+
+	private int getScale(String symbol) {
+		String tickSize = redisCacheService.get(RedisKey.TICK_SIZE_KEY_PREFIX.getValue() + symbol);
+		BigDecimal tickSizeDecimal = new BigDecimal(tickSize).stripTrailingZeros();
+		return Math.max(0, tickSizeDecimal.scale());
+	}
+
+	private BigDecimal getOpenPrice(String Symbol) {
+		return Optional.ofNullable(
+				redisCacheService.get(RedisKey.OPEN_PRICE_KEY_PREFIX.getValue() + Symbol)
+			)
+			.map(BigDecimal::new)
+			.orElse(BigDecimal.ZERO);
+	}
+}

--- a/src/main/java/com/zunza/buythedip/warmup/CacheWarmUpRunner.java
+++ b/src/main/java/com/zunza/buythedip/warmup/CacheWarmUpRunner.java
@@ -1,0 +1,40 @@
+package com.zunza.buythedip.warmup;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import com.zunza.buythedip.crypto.repository.CryptoRepository;
+import com.zunza.buythedip.infrastructure.redis.constant.RedisKey;
+import com.zunza.buythedip.infrastructure.redis.service.RedisCacheService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CacheWarmUpRunner implements ApplicationRunner {
+	private static final String SYMBOL_SUFFIX = "USDT";
+
+	private final CryptoRepository cryptoRepository;
+	private final RedisCacheService redisCacheService;
+
+	@Override
+	public void run(ApplicationArguments args) {
+		long startTime = System.currentTimeMillis();
+		log.info("tick size 캐싱 작업 시작");
+
+		cryptoRepository.findAll()
+			.forEach(crypto ->
+				redisCacheService.set(
+					RedisKey.TICK_SIZE_KEY_PREFIX.getValue() + crypto.getSymbol() + SYMBOL_SUFFIX,
+					crypto.getTickSize().toString()
+				)
+			);
+
+		long endTime = System.currentTimeMillis();
+		log.info("tick size 캐싱 작업이 완료되었습니다. (총 소요 시간: {}ms)]",
+			endTime - startTime);
+	}
+}


### PR DESCRIPTION
#### CacheWarmUpRunner
- CryptoService의 publishTicker는 초당 수십~수백 번 호출될 수 있는 매우 빈번한 메서드입니다. 만약 이 메서드 내부에서 tickSize 정보를 얻기 위해 매번 DB I/O를 발생시킨다면, 시스템은 DB 부하를 겪게 됩니다. 따라서 ApplicationRunner를 구현하여 애플리케이션 시작 시점 Cache Warming을 수행합니다.

#### CryptoService.publishTicker
- 데이터 조회: Redis에서 openPrice (시가)와 tickSize (가격 소수점 자리수)를 조회합니다.
- 데이터 가공: 조회한 데이터를 기반으로 changePrice (변동가)와 changeRate (변동률)을 계산합니다.
- 정밀도 처리: 각 암호화폐의 tickSize에 맞춰 BigDecimal.setScale()을 사용하여 클라이언트에게 표시할 가격의 소수점 자리수를 정확하게 맞춥니다.
- 메시지 발행: 최종적으로 TickerResponse DTO를 RedisMessagePublisher를 통해 TICKER_CHANNEL이라는 토픽으로 발행합니다.