### PR TITLE
feat: Redis Pub/Sub을 활용한 STOMP WebSocket 브로커 구현

### DIFF
--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/config/RedisListenerConfig.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/config/RedisListenerConfig.java
@@ -1,0 +1,38 @@
+package com.zunza.buythedip.infrastructure.redis.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter;
+
+import com.zunza.buythedip.infrastructure.redis.constant.Channels;
+import com.zunza.buythedip.infrastructure.redis.pubsub.RedisMessageSubscriber;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisListenerConfig {
+	private final RedisMessageSubscriber subscriber;
+	private final RedisConnectionFactory redisConnectionFactory;
+
+	@Bean
+	public ChannelTopic tickerChannelTopic() {
+		return new ChannelTopic(Channels.TICKER_CHANNEL.getTopic());
+	}
+
+	@Bean
+	public MessageListenerAdapter listenerAdapter() {
+		return new MessageListenerAdapter(subscriber, "sendMessage");
+	}
+
+	@Bean
+	public RedisMessageListenerContainer container() {
+		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+		container.setConnectionFactory(redisConnectionFactory);
+		container.addMessageListener(listenerAdapter(), tickerChannelTopic());
+		return container;
+	}
+}

--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/constant/Channels.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/constant/Channels.java
@@ -1,0 +1,20 @@
+package com.zunza.buythedip.infrastructure.redis.constant;
+
+import com.zunza.buythedip.crypto.dto.TickerResponse;
+
+import lombok.Getter;
+
+@Getter
+public enum Channels {
+	TICKER_CHANNEL("ticker", "/topic/ticker/", TickerResponse.class);
+
+	private String topic;
+	private String destinationPrefix;
+	private Class<?> type;
+
+	Channels(String topic, String destinationPrefix, Class<?> type) {
+		this.topic = topic;
+		this.destinationPrefix = destinationPrefix;
+		this.type = type;
+	}
+}

--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/pubsub/RedisMessagePublisher.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/pubsub/RedisMessagePublisher.java
@@ -1,0 +1,26 @@
+package com.zunza.buythedip.infrastructure.redis.pubsub;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisMessagePublisher {
+	private final ObjectMapper objectMapper;
+	private final StringRedisTemplate redisTemplate;
+
+	public void publishMessage(String topic, Object message) {
+		try {
+			redisTemplate.convertAndSend(topic, objectMapper.writeValueAsString(message));
+		} catch (JsonProcessingException e) {
+			log.warn(e.getMessage());
+		}
+	}
+}

--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/pubsub/RedisMessageSubscriber.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/pubsub/RedisMessageSubscriber.java
@@ -1,0 +1,63 @@
+package com.zunza.buythedip.infrastructure.redis.pubsub;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zunza.buythedip.crypto.dto.TickerResponse;
+import com.zunza.buythedip.infrastructure.redis.constant.Channels;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisMessageSubscriber {
+	private final ObjectMapper objectMapper;
+	private final SimpMessageSendingOperations messagingTemplate;
+
+	public void sendMessage(String message, String channel) {
+		Optional<Channels> channelOptional = getChannel(channel);
+
+		if (channelOptional.isEmpty()) {
+			log.warn("지원하지 않는 채널입니다: {}", channel);
+			return;
+		}
+
+		Channels channelEnum = channelOptional.get();
+
+		try {
+			Object payload = objectMapper.readValue(message, channelEnum.getType());
+			String destination = getDestination(channelEnum, payload);
+
+			if (destination.isEmpty()) {
+				log.warn("목적지를 찾을 수 없습니다. Channel: {}, Payload: {}", channel, payload);
+				return;
+			}
+
+			messagingTemplate.convertAndSend(destination, payload);
+
+		} catch (JsonProcessingException e) {
+			log.error("역직렬화 실패 Channel: {}, Message: {}", channel, message, e);
+		}
+	}
+
+	private Optional<Channels> getChannel(String channel) {
+		return Arrays.stream(Channels.values())
+			.filter(c -> c.getTopic().equals(channel))
+			.findFirst();
+	}
+
+	private String getDestination(Channels channel, Object payload) {
+		if (payload instanceof TickerResponse tickerResponse) {
+			return channel.getDestinationPrefix() + tickerResponse.getSymbol();
+		}
+
+		return "";
+	}
+}

--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/service/RedisCacheService.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/service/RedisCacheService.java
@@ -14,6 +14,10 @@ public class RedisCacheService {
 		redisTemplate.opsForValue().set(key, value);
 	}
 
+	public String get(String key) {
+		return redisTemplate.opsForValue().get((key));
+	}
+
 	public boolean delete(String key) {
 		return redisTemplate.delete(key);
 	}


### PR DESCRIPTION
#### RedisMessagePublisher
- Redis에 메시지를 쉽게 발행할 수 있도록 퍼블리셔입니다.
- StringRedisTemplate.convertAndSend()를 사용하여 메시지를 지정된 토픽으로 발행합니다.
#### RedisMessageSubscriber
- Redis로부터 메시지를 수신하는 리스너 컴포넌트입니다. (실제 리스너 등록 설정은 RedisListenerConfig에서 이루어집니다.)
- 수신된 channel(토픽) 이름을 Channels Enum과 매칭하여 처리 방법을 결정합니다.
- Channels Enum에 정의된 type 정보(ex: TickerResponse.class)를 사용하여 수신된 JSON 메시지를 해당 DTO 객체로 역직렬화합니다.
- 역직렬화된 객체의 속성(ex: tickerResponse.getSymbol())을 바탕으로 최종 STOMP 목적지(예: /topic/ticker/BTC)를 동적으로 생성합니다.
- SimpMessageSendingOperations를 통해 해당 목적지를 구독하고 있는 클라이언트들에게 최종적으로 메시지를 전송합니다.