### PR TITLE
feat: 암호화폐 검색(자동완성) API 구현

### DIFF
--- a/src/main/java/com/zunza/buythedip/crypto/controller/CryptoController.java
+++ b/src/main/java/com/zunza/buythedip/crypto/controller/CryptoController.java
@@ -1,0 +1,28 @@
+package com.zunza.buythedip.crypto.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.zunza.buythedip.crypto.dto.CryptoSuggestResponse;
+import com.zunza.buythedip.crypto.service.CryptoService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/cryptos")
+@RequiredArgsConstructor
+public class CryptoController {
+	private final CryptoService cryptoService;
+
+	@GetMapping("/suggest")
+	public ResponseEntity<List<CryptoSuggestResponse>> suggestCrypto(
+		@RequestParam String keyword
+	) {
+		return ResponseEntity.ok(cryptoService.suggestCrypto(keyword));
+	}
+}

--- a/src/main/java/com/zunza/buythedip/crypto/dto/CryptoSuggestResponse.java
+++ b/src/main/java/com/zunza/buythedip/crypto/dto/CryptoSuggestResponse.java
@@ -1,0 +1,13 @@
+package com.zunza.buythedip.crypto.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CryptoSuggestResponse {
+	private Long id;
+	private String name;
+	private String symbol;
+	private String logo;
+}

--- a/src/main/java/com/zunza/buythedip/crypto/repository/CryptoRepository.java
+++ b/src/main/java/com/zunza/buythedip/crypto/repository/CryptoRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import com.zunza.buythedip.crypto.dto.CryptoSuggestResponse;
 import com.zunza.buythedip.crypto.entity.Crypto;
 
 @Repository
@@ -19,4 +20,19 @@ public interface CryptoRepository extends JpaRepository<Crypto, Long> {
 		"""
 	)
 	List<Crypto> findBySymbols(@Param("symbols") List<String> symbols);
+
+	@Query(
+		"""
+		SELECT new com.zunza.buythedip.crypto.dto.CryptoSuggestResponse(
+		c.id,
+		c.name,
+		c.symbol,
+		c.logo
+		)
+		FROM Crypto c
+		WHERE LOWER(c.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
+		OR LOWER(c.symbol) LIKE LOWER(CONCAT('%', :keyword, '%'))
+		"""
+	)
+	List<CryptoSuggestResponse> findByKeyword(@Param("keyword") String keyword);
 }

--- a/src/main/java/com/zunza/buythedip/crypto/service/CryptoService.java
+++ b/src/main/java/com/zunza/buythedip/crypto/service/CryptoService.java
@@ -2,11 +2,14 @@ package com.zunza.buythedip.crypto.service;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
+import com.zunza.buythedip.crypto.dto.CryptoSuggestResponse;
 import com.zunza.buythedip.crypto.dto.TickerResponse;
+import com.zunza.buythedip.crypto.repository.CryptoRepository;
 import com.zunza.buythedip.external.binance.dto.TickerData;
 import com.zunza.buythedip.infrastructure.redis.constant.Channels;
 import com.zunza.buythedip.infrastructure.redis.constant.RedisKey;
@@ -20,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 public class CryptoService {
+	private final CryptoRepository cryptoRepository;
 	private final RedisCacheService redisCacheService;
 	private final RedisMessagePublisher redisMessagePublisher;
 
@@ -42,6 +46,10 @@ public class CryptoService {
 			Channels.TICKER_CHANNEL.getTopic(),
 			tickerResponse
 		);
+	}
+
+	public List<CryptoSuggestResponse> suggestCrypto(String keyword) {
+		return cryptoRepository.findByKeyword(keyword);
 	}
 
 	private BigDecimal getChangeRate(BigDecimal openPrice, BigDecimal currentPrice) {


### PR DESCRIPTION
#### CryptoController
- GET /suggest 엔드포인트를 추가했습니다.
- @RequestParam을 통해 keyword를 파라미터로 받아 검색 로직을 수행합니다.
#### CryptoRepository 
- WHERE LOWER(c.name) LIKE LOWER(CONCAT('%', :keyword, '%')) OR ...: LIKE와 와일드카드(%)를 사용하여 contains 검색을 구현했습니다.
- LOWER() 함수를 양쪽에 적용하여, 사용자가 'btc', 'BTC', 'Btc' 등 어떤 형태로 입력하더라도 'Bitcoin' (BTC)을 찾을 수 있도록 대소문자를 구분하지 않는 검색을 지원합니다.
- DTO 프로젝션 사용하여 조회 결과를 즉시 DTO로 반환합니다.