### PR TITLE
feat: 암호화폐 상세 정보 조회 API 및 캐싱 구현

### DIFF
--- a/src/main/java/com/zunza/buythedip/crypto/controller/CryptoController.java
+++ b/src/main/java/com/zunza/buythedip/crypto/controller/CryptoController.java
@@ -4,10 +4,12 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.zunza.buythedip.crypto.dto.CryptoDetailsResponse;
 import com.zunza.buythedip.crypto.dto.CryptoSuggestResponse;
 import com.zunza.buythedip.crypto.service.CryptoService;
 
@@ -24,5 +26,12 @@ public class CryptoController {
 		@RequestParam String keyword
 	) {
 		return ResponseEntity.ok(cryptoService.suggestCrypto(keyword));
+	}
+
+	@GetMapping("/{cryptoId}")
+	public ResponseEntity<CryptoDetailsResponse> getCryptoDetails(
+		@PathVariable Long cryptoId
+	) {
+		return ResponseEntity.ok(cryptoService.getCryptoDetails(cryptoId));
 	}
 }

--- a/src/main/java/com/zunza/buythedip/crypto/dto/CryptoDetailsResponse.java
+++ b/src/main/java/com/zunza/buythedip/crypto/dto/CryptoDetailsResponse.java
@@ -1,0 +1,33 @@
+package com.zunza.buythedip.crypto.dto;
+
+import java.util.List;
+
+import com.zunza.buythedip.crypto.entity.CryptoMetadata;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class CryptoDetailsResponse {
+	private String description;
+	private List<String> website;
+	private List<String> twitter;
+	private List<String> explorer;
+	private List<String> tags;
+
+	public static CryptoDetailsResponse createFrom(CryptoMetadata metadata) {
+		return CryptoDetailsResponse.builder()
+			.description(metadata.getDescription())
+			.website(metadata.getWebsite())
+			.twitter(metadata.getTwitter())
+			.explorer(metadata.getExplorer())
+			.tags(metadata.getTags())
+			.build();
+	}
+}

--- a/src/main/java/com/zunza/buythedip/crypto/exception/CryptoMetadataNotFoundException.java
+++ b/src/main/java/com/zunza/buythedip/crypto/exception/CryptoMetadataNotFoundException.java
@@ -1,0 +1,18 @@
+package com.zunza.buythedip.crypto.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.zunza.buythedip.common.CustomException;
+
+public class CryptoMetadataNotFoundException extends CustomException {
+	private static final String MESSAGE = "암호화폐에 대한 상세정보가 존재하지 않습니다.";
+
+	public CryptoMetadataNotFoundException() {
+		super(MESSAGE);
+	}
+
+	@Override
+	public int getStatusCode() {
+		return HttpStatus.NOT_FOUND.value();
+	}
+}

--- a/src/main/java/com/zunza/buythedip/crypto/repository/CryptoMetadataRepository.java
+++ b/src/main/java/com/zunza/buythedip/crypto/repository/CryptoMetadataRepository.java
@@ -1,5 +1,7 @@
 package com.zunza.buythedip.crypto.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +9,5 @@ import com.zunza.buythedip.crypto.entity.CryptoMetadata;
 
 @Repository
 public interface CryptoMetadataRepository extends JpaRepository<CryptoMetadata, Long> {
+	Optional<CryptoMetadata> findByCryptoId(Long cryptoId);
 }

--- a/src/main/java/com/zunza/buythedip/crypto/service/CryptoService.java
+++ b/src/main/java/com/zunza/buythedip/crypto/service/CryptoService.java
@@ -5,10 +5,16 @@ import java.math.RoundingMode;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.zunza.buythedip.crypto.dto.CryptoDetailsResponse;
 import com.zunza.buythedip.crypto.dto.CryptoSuggestResponse;
 import com.zunza.buythedip.crypto.dto.TickerResponse;
+import com.zunza.buythedip.crypto.entity.CryptoMetadata;
+import com.zunza.buythedip.crypto.exception.CryptoMetadataNotFoundException;
+import com.zunza.buythedip.crypto.repository.CryptoMetadataRepository;
 import com.zunza.buythedip.crypto.repository.CryptoRepository;
 import com.zunza.buythedip.external.binance.dto.TickerData;
 import com.zunza.buythedip.infrastructure.redis.constant.Channels;
@@ -26,6 +32,7 @@ public class CryptoService {
 	private final CryptoRepository cryptoRepository;
 	private final RedisCacheService redisCacheService;
 	private final RedisMessagePublisher redisMessagePublisher;
+	private final CryptoMetadataRepository cryptoMetadataRepository;
 
 	public void publishTicker(TickerData data) {
 		BigDecimal openPrice = getOpenPrice(data.getSymbol());
@@ -48,8 +55,18 @@ public class CryptoService {
 		);
 	}
 
+	@Transactional(readOnly = true)
 	public List<CryptoSuggestResponse> suggestCrypto(String keyword) {
 		return cryptoRepository.findByKeyword(keyword);
+	}
+
+	@Transactional(readOnly = true)
+	@Cacheable(cacheNames = "CRYPTO:DETAILS", key = "#cryptoId")
+	public CryptoDetailsResponse getCryptoDetails(Long cryptoId) {
+		CryptoMetadata metadata = cryptoMetadataRepository.findByCryptoId(cryptoId)
+			.orElseThrow(CryptoMetadataNotFoundException::new);
+
+		return CryptoDetailsResponse.createFrom(metadata);
 	}
 
 	private BigDecimal getChangeRate(BigDecimal openPrice, BigDecimal currentPrice) {

--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/config/RedisCacheConfig.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/config/RedisCacheConfig.java
@@ -1,0 +1,39 @@
+package com.zunza.buythedip.infrastructure.redis.config;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.zunza.buythedip.infrastructure.redis.constant.CacheType;
+
+@EnableCaching
+@Configuration
+public class RedisCacheConfig {
+
+	@Bean
+	public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+		RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+			.serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+			.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+		Map<String, RedisCacheConfiguration> cacheConfiguration = Arrays.stream(CacheType.values())
+			.collect(Collectors.toMap(CacheType::getCacheName, cacheType -> config.entryTtl(cacheType.getTtl())));
+
+		return RedisCacheManager.builder(redisConnectionFactory)
+			.cacheDefaults(config.entryTtl(Duration.ofMinutes(1)))
+			.withInitialCacheConfigurations(cacheConfiguration)
+			.build();
+	}
+}

--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/constant/CacheType.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/constant/CacheType.java
@@ -1,0 +1,18 @@
+package com.zunza.buythedip.infrastructure.redis.constant;
+
+import java.time.Duration;
+
+import lombok.Getter;
+
+@Getter
+public enum CacheType {
+	CRYPTO_DETAILS("CRYPTO:DETAILS", Duration.ofMinutes(10));
+
+	private String cacheName;
+	private Duration ttl;
+
+	CacheType(String cacheName, Duration ttl) {
+		this.cacheName = cacheName;
+		this.ttl = ttl;
+	}
+}


### PR DESCRIPTION
#### @Cacheable을 통한 캐싱 적용
- 메서드 호출 시, Spring AOP 프록시가 요청을 가로챕니다.
- Redis에서 key 에 해당하는 값이 있는지 확인합니다.
- 값이 존재하면, 메서드(getCryptoDetails)를 실행하지 않고 캐시된 값을 반환합니다.
- 값이 없으면, 메서드를 실행하여 DB에서 데이터를 조회하고, 그 반환 값을 캐시에 저장한 후 클라이언트에게 응답합니다.
#### RedisCacheConfig
- Keys: StringRedisSerializer를 사용하여 Redis의 키가 평문으로 저장되도록 합니다. (예: CRYPTO:DETAILS::1)
- Values: GenericJackson2JsonRedisSerializer를 사용하여 DTO 객체가 JSON 형식으로 저장되도록 합니다.
#### CacheType Enum
- CRYPTO_DETAILS("CRYPTO:DETAILS", Duration.ofMinutes(10)) 와 같이 캐시의 이름과 TTL을 Enum으로 관리합니다.