### PR TITLE
feat: Redis를 활용한 분산 락을 적용한 캐싱 어노테이션 구현

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/buythedip.main.iml" filepath="$PROJECT_DIR$/.idea/modules/buythedip.main.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/modules/buythedip.main.iml
+++ b/.idea/modules/buythedip.main.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/main">
+      <sourceFolder url="file://$MODULE_DIR$/../../build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
+    </content>
+  </component>
+</module>

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'io.jsonwebtoken:jjwt:0.12.6' // JWT
+	implementation 'org.springframework.boot:spring-boot-starter-aop' // AOP
+	implementation 'org.redisson:redisson-spring-boot-starter:3.50.0' // Redisson
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.boot:spring-boot-testcontainers'

--- a/src/main/java/com/zunza/buythedip/common/annotation/CacheableWithDistributedLock.java
+++ b/src/main/java/com/zunza/buythedip/common/annotation/CacheableWithDistributedLock.java
@@ -1,0 +1,23 @@
+package com.zunza.buythedip.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CacheableWithDistributedLock {
+
+	String[] value() default {};
+
+	String key() default "";
+
+	long maxWaitTime() default 5000;
+
+	long lockExpireTime() default 30;
+
+	long retryInterval() default 100;
+
+	boolean allowFallback() default true;
+}

--- a/src/main/java/com/zunza/buythedip/common/annotation/aop/CacheableWithDistributedLockAspect.java
+++ b/src/main/java/com/zunza/buythedip/common/annotation/aop/CacheableWithDistributedLockAspect.java
@@ -1,0 +1,142 @@
+package com.zunza.buythedip.common.annotation.aop;
+
+import java.lang.reflect.Method;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.core.DefaultParameterNameDiscoverer;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.stereotype.Component;
+
+import com.zunza.buythedip.common.annotation.CacheableWithDistributedLock;
+import com.zunza.buythedip.infrastructure.redis.service.RedisDistributedLock;
+
+import lombok.RequiredArgsConstructor;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class CacheableWithDistributedLockAspect {
+	private final RedisDistributedLock distributedLock;
+	private final CacheManager cacheManager;
+	private final DefaultParameterNameDiscoverer parameterNameDiscoverer = new DefaultParameterNameDiscoverer();
+	private final ExpressionParser expressionParser = new SpelExpressionParser();
+
+	@Around("@annotation(cacheableWithDistributedLock)")
+	public Object handleCacheableWithDistributedLock(
+		ProceedingJoinPoint joinPoint,
+		CacheableWithDistributedLock cacheableWithDistributedLock
+	) throws Throwable {
+
+		MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+		Method method = signature.getMethod();
+		Object[] args = joinPoint.getArgs();
+
+		String cacheName = determineCacheName(cacheableWithDistributedLock, method);
+		String cacheKey = calculateCacheKey(cacheableWithDistributedLock, method, args);
+
+		Cache cache = cacheManager.getCache(cacheName);
+		if (cache == null) {
+			throw new IllegalArgumentException("캐시가 존재하지 않습니다. [cache name]: " + cacheName);
+		}
+
+		Cache.ValueWrapper cachedValue = cache.get(cacheKey);
+		if (cachedValue != null) {
+			return cachedValue.get();
+		}
+
+		return executeWithDistributedLock(joinPoint, cache, cacheKey, cacheableWithDistributedLock);
+	}
+
+	private String determineCacheName(
+		CacheableWithDistributedLock annotation,
+		Method method
+	) {
+		if (annotation.value().length > 0) {
+			return annotation.value()[0];
+		}
+
+		return method.getDeclaringClass().getSimpleName() + "." + method.getName();
+	}
+
+	private String calculateCacheKey(
+		CacheableWithDistributedLock annotation,
+		Method method,
+		Object[] args
+	) {
+		if (!annotation.key().isEmpty()) {
+			return evaluateSpelExpression(annotation.key(), method, args);
+		}
+
+		StringBuilder keyBuilder = new StringBuilder();
+		for (int i = 0; i < args.length; i++) {
+			if (i > 0) keyBuilder.append(":");
+			keyBuilder.append(args[i] != null ? args[i].toString() : "null");
+		}
+		return keyBuilder.toString();
+	}
+
+	private String evaluateSpelExpression(
+		String expression,
+		Method method,
+		Object[] args
+	) {
+		Expression spelExpression = expressionParser.parseExpression(expression);
+		EvaluationContext context = new StandardEvaluationContext();
+
+		String[] paramNames = parameterNameDiscoverer.getParameterNames(method);
+
+		for (int i = 0; i < args.length; i++) {
+			context.setVariable(paramNames[i], args[i]);
+		}
+
+		return spelExpression.getValue(context, String.class);
+	}
+
+	private Object executeWithDistributedLock(
+		ProceedingJoinPoint joinPoint,
+		Cache cache,
+		String cacheKey,
+		CacheableWithDistributedLock annotation
+	) throws Throwable {
+		String lockKey = "lock:" + cache.getName() + ":" + cacheKey;
+
+		RedisDistributedLock.LockInfo lockInfo = distributedLock.tryLockWithRetry(
+			lockKey,
+			annotation.lockExpireTime(),
+			annotation.maxWaitTime(),
+			annotation.retryInterval()
+		);
+
+		if (lockInfo != null) {
+			try {
+				Cache.ValueWrapper cachedValue = cache.get(cacheKey);
+				if (cachedValue != null) {
+					return cachedValue.get();
+				}
+
+				Object result = joinPoint.proceed();
+				cache.put(cacheKey, result);
+
+				return result;
+
+			} finally {
+				distributedLock.unlock(lockInfo);
+			}
+		} else {
+			if (annotation.allowFallback()) {
+				return joinPoint.proceed();
+			} else {
+				throw new RuntimeException("분산 락을 획득하지 못했습니다. [cache key]: " + cacheKey);
+			}
+		}
+	}
+}

--- a/src/main/java/com/zunza/buythedip/crypto/service/CryptoService.java
+++ b/src/main/java/com/zunza/buythedip/crypto/service/CryptoService.java
@@ -5,14 +5,13 @@ import java.math.RoundingMode;
 import java.util.List;
 import java.util.Optional;
 
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.zunza.buythedip.common.annotation.CacheableWithDistributedLock;
 import com.zunza.buythedip.crypto.dto.CryptoDetailsResponse;
 import com.zunza.buythedip.crypto.dto.CryptoSuggestResponse;
 import com.zunza.buythedip.crypto.dto.TickerResponse;
-import com.zunza.buythedip.crypto.entity.CryptoMetadata;
 import com.zunza.buythedip.crypto.exception.CryptoMetadataNotFoundException;
 import com.zunza.buythedip.crypto.repository.CryptoMetadataRepository;
 import com.zunza.buythedip.crypto.repository.CryptoRepository;
@@ -61,12 +60,11 @@ public class CryptoService {
 	}
 
 	@Transactional(readOnly = true)
-	@Cacheable(cacheNames = "CRYPTO:DETAILS", key = "#cryptoId")
+	@CacheableWithDistributedLock(value = "CRYPTO:DETAILS", key = "#cryptoId")
 	public CryptoDetailsResponse getCryptoDetails(Long cryptoId) {
-		CryptoMetadata metadata = cryptoMetadataRepository.findByCryptoId(cryptoId)
+		return cryptoMetadataRepository.findByCryptoId(cryptoId)
+			.map(CryptoDetailsResponse::createFrom)
 			.orElseThrow(CryptoMetadataNotFoundException::new);
-
-		return CryptoDetailsResponse.createFrom(metadata);
 	}
 
 	private BigDecimal getChangeRate(BigDecimal openPrice, BigDecimal currentPrice) {

--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/service/RedisDistributedLock.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/service/RedisDistributedLock.java
@@ -1,0 +1,97 @@
+package com.zunza.buythedip.infrastructure.redis.service;
+
+import java.util.Collections;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class RedisDistributedLock {
+	private final StringRedisTemplate redisTemplate;
+
+	private static final String UNLOCK_SCRIPT =
+		"if redis.call('get', KEYS[1]) == ARGV[1] then " +
+			"    return redis.call('del', KEYS[1]) " +
+			"else " +
+			"    return 0 " +
+			"end";
+
+	private final DefaultRedisScript<Long> unlockScript;
+
+	public RedisDistributedLock(StringRedisTemplate redisTemplate) {
+		this.redisTemplate = redisTemplate;
+		this.unlockScript = new DefaultRedisScript<>();
+		this.unlockScript.setScriptText(UNLOCK_SCRIPT);
+		this.unlockScript.setResultType(Long.class);
+	}
+
+	public boolean tryLock(
+		String lockKey,
+		String lockValue,
+		long expireTime
+	) {
+		Boolean result = redisTemplate.opsForValue()
+			.setIfAbsent(lockKey, lockValue, expireTime, TimeUnit.SECONDS);
+		return Boolean.TRUE.equals(result);
+	}
+
+	public LockInfo tryLockWithRetry(
+		String lockKey,
+		long expireTime,
+		long maxWaitTime,
+		long retryInterval
+	) {
+		String lockValue = UUID.randomUUID().toString();
+		long startTime = System.currentTimeMillis();
+
+		while (System.currentTimeMillis() - startTime < maxWaitTime) {
+			if (tryLock(lockKey, lockValue, expireTime)) {
+				return new LockInfo(lockKey, lockValue);
+			}
+
+			try {
+				Thread.sleep(retryInterval);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				return null;
+			}
+		}
+
+		return null;
+	}
+
+	public boolean unlock(String lockKey, String lockValue) {
+		Long result = redisTemplate.execute(unlockScript,
+			Collections.singletonList(lockKey), lockValue);
+		return Long.valueOf(1).equals(result);
+	}
+
+	public boolean unlock(LockInfo lockInfo) {
+		if (lockInfo == null) {
+			return false;
+		}
+		return unlock(lockInfo.getLockKey(), lockInfo.getLockValue());
+	}
+
+	public static class LockInfo {
+		private final String lockKey;
+		private final String lockValue;
+
+		public LockInfo(String lockKey, String lockValue) {
+			this.lockKey = lockKey;
+			this.lockValue = lockValue;
+		}
+
+		public String getLockKey() {
+			return lockKey;
+		}
+
+		public String getLockValue() {
+			return lockValue;
+		}
+	}
+}


### PR DESCRIPTION
closed #20 

#### 캐시 스탬피드
- 빈번하게 조회되는 데이터(예: 인기 암호화폐 상세정보)의 캐시가 만료됩니다.
- 동시에 여러 사용자 요청이 해당 데이터에 접근합니다.
- 다수의 요청이 캐시 미스를 경험하고, 모두 동시에 데이터베이스에 동일한 데이터를 조회하는 쿼리를 날립니다.
- 동시에 캐시를 생성하려고 합니다.
- 순간적인 DB 부하로 인해 응답 지연이 발생하거나, 심한 경우 DB 서버가 다운될 수 있습니다.
- 단순 @Cacheable 어노테이션은 이 문제를 해결할 수 없습니다.

#### 해결 방안: 분산 락을 활용한 제어
- @CacheableWithDistributedLock: 캐싱이 필요한 메서드에 이 어노테이션만 붙이면, 아래의 복잡한 동시성 제어 로직이 자동으로 적용됩니다.
- CacheableWithDistributedLockAspect: 어노테이션을 감지하여 아래와 같은 흐름으로 동작합니다.
  - 캐시 조회: 먼저 캐시에 데이터가 있는지 확인합니다. (캐시 히트 시 즉시 반환)
  - 캐시 미스 시 분산 락 획득 시도: Redis를 통해 분산 락을 획득합니다. 락 획득에 실패한 다른 스레드들은 잠시 대기합니다.
  - 락 획득 성공 후, 캐시 재조회: 락을 기다리는 동안 다른 스레드가 이미 캐시를 생성했을 수 있으므로, 캐시를 다시 한번 확인합니다. (캐시 히트 시 락 해제 후 즉시 반환)
  - 여전히 캐시가 없다면, DB를 조회하여 데이터를 가져온 후 캐시에 저장합니다.
  - finally 블록에서 락을 해제하여 다른 스레드가 작업을 이어갈 수 있도록 합니다.

#### RedisDistributedLock
- setIfAbsent: SET key value NX EX seconds 명령을 원자적으로 실행하여 락을 설정합니다.
- 락을 해제할 때, 락의 value(UUID)를 비교하여 자신이 설정한 락이 맞는지 확인 후 삭제하는 Lua 스크립트를 실행합니다.