### PR TITLE
feat: Binance WebSocket을 활용한 실시간 암호화폐 차트 데이터 스트리밍 구현

### DIFF
--- a/src/main/java/com/zunza/buythedip/external/binance/dto/klinestream/KlineData.java
+++ b/src/main/java/com/zunza/buythedip/external/binance/dto/klinestream/KlineData.java
@@ -1,0 +1,16 @@
+package com.zunza.buythedip.external.binance.dto.klinestream;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KlineData {
+	@JsonProperty("s")
+	private String symbol;
+
+	@JsonProperty("k")
+	private KlineDetails details;
+}

--- a/src/main/java/com/zunza/buythedip/external/binance/dto/klinestream/KlineDetails.java
+++ b/src/main/java/com/zunza/buythedip/external/binance/dto/klinestream/KlineDetails.java
@@ -1,0 +1,33 @@
+package com.zunza.buythedip.external.binance.dto.klinestream;
+
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KlineDetails {
+	@JsonProperty("i")
+	private String interval;
+
+	@JsonProperty("t")
+	private long time;
+
+	@JsonProperty("o")
+	private BigDecimal open;
+
+	@JsonProperty("h")
+	private BigDecimal high;
+
+	@JsonProperty("l")
+	private BigDecimal low;
+
+	@JsonProperty("c")
+	private BigDecimal close;
+
+	@JsonProperty("v")
+	private BigDecimal volume;
+}

--- a/src/main/java/com/zunza/buythedip/external/binance/dto/klinestream/KlineStreamResponse.java
+++ b/src/main/java/com/zunza/buythedip/external/binance/dto/klinestream/KlineStreamResponse.java
@@ -1,0 +1,12 @@
+package com.zunza.buythedip.external.binance.dto.klinestream;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KlineStreamResponse {
+	private KlineData data;
+}

--- a/src/main/java/com/zunza/buythedip/external/binance/stream/handler/KlineStreamHandler.java
+++ b/src/main/java/com/zunza/buythedip/external/binance/stream/handler/KlineStreamHandler.java
@@ -1,0 +1,60 @@
+package com.zunza.buythedip.external.binance.stream.handler;
+
+import java.util.List;
+
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zunza.buythedip.crypto.service.CryptoService;
+import com.zunza.buythedip.external.binance.dto.klinestream.KlineStreamResponse;
+import com.zunza.buythedip.external.binance.dto.SubscribeRequest;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class KlineStreamHandler extends TextWebSocketHandler {
+	private final String interval;
+	private final List<String> symbols;
+	private final int chunkSize;
+	private final ObjectMapper objectMapper;
+	private final CryptoService cryptoService;
+
+	@Override
+	public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+		for (int i = 0; i < symbols.size(); i += chunkSize) {
+			List<String> chunk = symbols.subList(i, Math.min(i + chunkSize, symbols.size()));
+
+			List<String> subscribeParams = chunk.stream()
+				.map(symbol -> symbol + interval)
+				.toList();
+
+			SubscribeRequest request = new SubscribeRequest(
+				"SUBSCRIBE",
+				subscribeParams,
+				String.valueOf(i / chunkSize + 1)
+			);
+
+			String payload = objectMapper.writeValueAsString(request);
+			session.sendMessage(new TextMessage(payload));
+			Thread.sleep(200);
+		}
+	}
+
+	@Override
+	protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+		KlineStreamResponse response = objectMapper.readValue(
+			message.getPayload(),
+			KlineStreamResponse.class
+		);
+
+		if (response.getData() == null) {
+			return;
+		}
+
+		cryptoService.publishKline(response.getData());
+	}
+}

--- a/src/main/java/com/zunza/buythedip/external/binance/stream/manager/KlineStreamManager.java
+++ b/src/main/java/com/zunza/buythedip/external/binance/stream/manager/KlineStreamManager.java
@@ -1,0 +1,55 @@
+package com.zunza.buythedip.external.binance.stream.manager;
+
+import java.util.List;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.client.WebSocketClient;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zunza.buythedip.crypto.repository.CryptoRepository;
+import com.zunza.buythedip.crypto.service.CryptoService;
+import com.zunza.buythedip.external.binance.stream.handler.KlineStreamHandler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KlineStreamManager {
+	private final ObjectMapper objectMapper;
+	private final WebSocketClient webSocketClient;
+	private final CryptoService cryptoService;
+	private final CryptoRepository cryptoRepository;
+
+	private static final String KLINE_STREAM_URL = "wss://data-stream.binance.vision/stream";
+	private static final String STREAM_SUFFIX = "usdt@kline_";
+	private static final List<String> KLINE_INTERVALS = List.of("1m", "3m", "5m", "15m", "30m", "1h", "4h", "1d", "1w", "1M");
+	private static final int CHUNK_SIZE = 203;
+
+	@EventListener(ApplicationReadyEvent.class)
+	public void startStreaming() {
+		List<String> symbols = cryptoRepository.findAll().stream()
+			.map(crypto -> crypto.getSymbol().toLowerCase() + STREAM_SUFFIX)
+			.toList();
+
+		if (symbols.isEmpty()) {
+			log.warn("심볼이 존재하지 않습니다.");
+			return;
+		}
+
+		KLINE_INTERVALS.forEach(interval -> {
+			KlineStreamHandler handler = new KlineStreamHandler(
+				interval,
+				symbols,
+				CHUNK_SIZE,
+				objectMapper,
+				cryptoService
+			);
+
+			webSocketClient.execute(handler, KLINE_STREAM_URL);
+		});
+	}
+}

--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/config/RedisListenerConfig.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/config/RedisListenerConfig.java
@@ -24,6 +24,11 @@ public class RedisListenerConfig {
 	}
 
 	@Bean
+	public ChannelTopic chartChannelTopic() {
+		return new ChannelTopic(Channels.CHART_CHANNEL.getTopic());
+	}
+
+	@Bean
 	public MessageListenerAdapter listenerAdapter() {
 		return new MessageListenerAdapter(subscriber, "sendMessage");
 	}
@@ -33,6 +38,7 @@ public class RedisListenerConfig {
 		RedisMessageListenerContainer container = new RedisMessageListenerContainer();
 		container.setConnectionFactory(redisConnectionFactory);
 		container.addMessageListener(listenerAdapter(), tickerChannelTopic());
+		container.addMessageListener(listenerAdapter(), chartChannelTopic());
 		return container;
 	}
 }

--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/constant/Channels.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/constant/Channels.java
@@ -1,12 +1,14 @@
 package com.zunza.buythedip.infrastructure.redis.constant;
 
+import com.zunza.buythedip.crypto.dto.ChartResponse;
 import com.zunza.buythedip.crypto.dto.TickerResponse;
 
 import lombok.Getter;
 
 @Getter
 public enum Channels {
-	TICKER_CHANNEL("ticker", "/topic/ticker/", TickerResponse.class);
+	TICKER_CHANNEL("ticker", "/topic/ticker/", TickerResponse.class),
+	CHART_CHANNEL("chart", "/topic/chart/", ChartResponse.class);
 
 	private String topic;
 	private String destinationPrefix;

--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/pubsub/RedisMessageSubscriber.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/pubsub/RedisMessageSubscriber.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zunza.buythedip.crypto.dto.ChartResponse;
 import com.zunza.buythedip.crypto.dto.TickerResponse;
 import com.zunza.buythedip.infrastructure.redis.constant.Channels;
 
@@ -54,10 +55,12 @@ public class RedisMessageSubscriber {
 	}
 
 	private String getDestination(Channels channel, Object payload) {
-		if (payload instanceof TickerResponse tickerResponse) {
-			return channel.getDestinationPrefix() + tickerResponse.getSymbol();
-		}
-
-		return "";
+		return switch (payload) {
+			case TickerResponse tickerResponse ->
+				channel.getDestinationPrefix() + tickerResponse.getSymbol();
+			case ChartResponse chartResponse ->
+				channel.getDestinationPrefix() + chartResponse.getSymbol() + "/" + chartResponse.getInterval();
+			default -> "";
+		};
 	}
 }


### PR DESCRIPTION
#### 실시간 차트를 구현하기 위한 백엔드 파이프라인을 구축합니다. Binance WebSocket 스트림을 통해 모든(바이낸스 현물) 암호화폐에 대한 다양한 시간 간격의 Kline(캔들스틱) 데이터를 실시간으로 수신하고, 이를 최종적으로 클라이언트에게 전달할 수 있도록 시스템 전체에 발행합니다.

#### KlineStreamManager
- 모든 시간 간격(KLINE_INTERVALS)에 대해 루프를 돌며 각각 별도의 WebSocketClient와 KlineStreamHandler를 생성합니다.

#### KlineStreamHandler
- 생성 시 특정 interval 값을 주입받아, 해당 인터벌에 대한 구독 요청({symbol}usdt@kline_{interval})을 동적으로 생성합니다.
- 수신한 데이터는 가공을 위해 cryptoService.publishKline으로 전달합니다.

#### 데이터 처리 및 발행 파이프라인
- 수신된 KlineData를 클라이언트가 사용하기 용이한 ChartResponse로 변환하고, Redis의 chart 토픽으로 발행합니다.

#### RedisMessageSubscriber
- getDestination 메서드를 switch 문의 패턴 매칭을 사용하도록 리팩토링했습니다.