### PR TITLE
feat: 초기 차트 데이터를 위한 API 구현

### DIFF
--- a/src/main/java/com/zunza/buythedip/crypto/controller/CryptoController.java
+++ b/src/main/java/com/zunza/buythedip/crypto/controller/CryptoController.java
@@ -9,12 +9,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.zunza.buythedip.crypto.dto.ChartResponse;
 import com.zunza.buythedip.crypto.dto.CryptoDetailsResponse;
 import com.zunza.buythedip.crypto.dto.CryptoSuggestResponse;
 import com.zunza.buythedip.crypto.service.CryptoService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/cryptos")
 @RequiredArgsConstructor
@@ -33,5 +36,13 @@ public class CryptoController {
 		@PathVariable Long cryptoId
 	) {
 		return ResponseEntity.ok(cryptoService.getCryptoDetails(cryptoId));
+	}
+
+	@GetMapping("/chart")
+	public ResponseEntity<List<ChartResponse>> getCryptoChart(
+		@RequestParam String symbol,
+		@RequestParam(defaultValue = "15m") String interval
+	) {
+		return ResponseEntity.ok(cryptoService.getCryptoChart(symbol, interval));
 	}
 }

--- a/src/main/java/com/zunza/buythedip/crypto/dto/ChartResponse.java
+++ b/src/main/java/com/zunza/buythedip/crypto/dto/ChartResponse.java
@@ -1,0 +1,89 @@
+package com.zunza.buythedip.crypto.dto;
+
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.zunza.buythedip.external.binance.dto.KlineRestApiResponse;
+import com.zunza.buythedip.external.binance.dto.klinestream.KlineData;
+import com.zunza.buythedip.external.binance.dto.klinestream.KlineDetails;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChartResponse {
+	private static final String COLOR_BULLISH = "rgba(244, 67, 54, 1.0)";
+	private static final String COLOR_BEARISH = "rgba(76, 175, 80, 1.0)";
+
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private String symbol;
+	@JsonInclude(JsonInclude.Include.NON_NULL)
+	private String interval;
+	private Candle candle;
+	private Volume volume;
+
+	public static ChartResponse createHistoryResponse(KlineRestApiResponse response, int scale) {
+		long time = response.getOpenTime() / 1000;
+		BigDecimal open = response.getOpen().setScale(scale);
+		BigDecimal high = response.getHigh().setScale(scale);
+		BigDecimal low = response.getLow().setScale(scale);
+		BigDecimal close = response.getClose().setScale(scale);
+		BigDecimal value = response.getVolume().stripTrailingZeros();
+		String color = open.compareTo(close) >= 0 ? COLOR_BULLISH : COLOR_BEARISH;
+
+		Candle candle = new Candle(time, open, high, low, close);
+		Volume volume = new Volume(time, value, color);
+
+		return ChartResponse.builder()
+			.candle(candle)
+			.volume(volume)
+			.build();
+	}
+
+	public static ChartResponse createUpdateResponse(KlineData data, int scale) {
+		KlineDetails details = data.getDetails();
+
+		long time = details.getTime() / 1000;
+		BigDecimal open = details.getOpen().setScale(scale);
+		BigDecimal high = details.getHigh().setScale(scale);
+		BigDecimal low = details.getLow().setScale(scale);
+		BigDecimal close = details.getClose().setScale(scale);
+		BigDecimal value = details.getVolume().stripTrailingZeros();
+		String color = open.compareTo(close) >= 0 ? COLOR_BULLISH : COLOR_BEARISH;
+
+		String symbol = data.getSymbol().replace("USDT", "");
+		String interval = details.getInterval();
+
+		Candle candle = new Candle(time, open, high, low, close);
+		Volume volume = new Volume(time, value, color);
+
+		return ChartResponse.builder()
+			.symbol(symbol)
+			.interval(interval)
+			.candle(candle)
+			.volume(volume)
+			.build();
+	}
+
+	@Getter
+	@AllArgsConstructor
+	public static class Candle {
+		private long time;
+		private BigDecimal open;
+		private BigDecimal high;
+		private BigDecimal low;
+		private BigDecimal close;
+	}
+
+	@Getter
+	@AllArgsConstructor
+	public static class Volume {
+		private long time;
+		private BigDecimal value;
+		private String color;
+	}
+}

--- a/src/main/java/com/zunza/buythedip/crypto/service/CryptoService.java
+++ b/src/main/java/com/zunza/buythedip/crypto/service/CryptoService.java
@@ -9,13 +9,16 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.zunza.buythedip.common.annotation.CacheableWithDistributedLock;
+import com.zunza.buythedip.crypto.dto.ChartResponse;
 import com.zunza.buythedip.crypto.dto.CryptoDetailsResponse;
 import com.zunza.buythedip.crypto.dto.CryptoSuggestResponse;
 import com.zunza.buythedip.crypto.dto.TickerResponse;
 import com.zunza.buythedip.crypto.exception.CryptoMetadataNotFoundException;
 import com.zunza.buythedip.crypto.repository.CryptoMetadataRepository;
 import com.zunza.buythedip.crypto.repository.CryptoRepository;
-import com.zunza.buythedip.external.binance.dto.TickerData;
+import com.zunza.buythedip.external.binance.client.BinanceClient;
+import com.zunza.buythedip.external.binance.dto.klinestream.KlineData;
+import com.zunza.buythedip.external.binance.dto.tickerstream.TickerData;
 import com.zunza.buythedip.infrastructure.redis.constant.Channels;
 import com.zunza.buythedip.infrastructure.redis.constant.RedisKey;
 import com.zunza.buythedip.infrastructure.redis.pubsub.RedisMessagePublisher;
@@ -28,6 +31,9 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 public class CryptoService {
+	private static final String SYMBOL_SUFFIX = "USDT";
+
+	private final BinanceClient binanceClient;
 	private final CryptoRepository cryptoRepository;
 	private final RedisCacheService redisCacheService;
 	private final RedisMessagePublisher redisMessagePublisher;
@@ -39,10 +45,11 @@ public class CryptoService {
 		BigDecimal changePrice = currentPrice.subtract(openPrice);
 		BigDecimal changeRate = getChangeRate(openPrice, currentPrice);
 
-		int scale = getScale(data.getSymbol());
+		String tickSize = redisCacheService.get(RedisKey.TICK_SIZE_KEY_PREFIX.getValue() + data.getSymbol());
+		int scale = getScale(tickSize);
 
 		TickerResponse tickerResponse = TickerResponse.createOf(
-			data.getSymbol().replace("USDT", ""),
+			data.getSymbol().replace(SYMBOL_SUFFIX, ""),
 			currentPrice.setScale(scale, RoundingMode.HALF_UP),
 			changePrice.setScale(scale, RoundingMode.HALF_UP),
 			changeRate.setScale(2, RoundingMode.HALF_UP)
@@ -51,6 +58,19 @@ public class CryptoService {
 		redisMessagePublisher.publishMessage(
 			Channels.TICKER_CHANNEL.getTopic(),
 			tickerResponse
+		);
+	}
+
+	public void publishKline(KlineData data) {
+		String tickSizeKey = RedisKey.TICK_SIZE_KEY_PREFIX.getValue() + data.getSymbol();
+		String tickSize = redisCacheService.get(tickSizeKey);
+		int scale = getScale(tickSize);
+
+		ChartResponse chartResponse = ChartResponse.createUpdateResponse(data, scale);
+
+		redisMessagePublisher.publishMessage(
+			Channels.CHART_CHANNEL.getTopic(),
+			chartResponse
 		);
 	}
 
@@ -67,6 +87,22 @@ public class CryptoService {
 			.orElseThrow(CryptoMetadataNotFoundException::new);
 	}
 
+	public List<ChartResponse> getCryptoChart(
+		String symbol,
+		String interval
+	) {
+		String binanceSymbol = symbol + SYMBOL_SUFFIX;
+		String tickSizeKey = RedisKey.TICK_SIZE_KEY_PREFIX.getValue() + binanceSymbol;
+		String tickSize = redisCacheService.get(tickSizeKey);
+		int scale = getScale(tickSize);
+
+		return binanceClient.getKline(binanceSymbol, interval, 200)
+			.block()
+			.stream()
+			.map(kline -> ChartResponse.createHistoryResponse(kline, scale))
+			.toList();
+	}
+
 	private BigDecimal getChangeRate(BigDecimal openPrice, BigDecimal currentPrice) {
 		if (openPrice.compareTo(BigDecimal.ZERO) == 0) {
 			return BigDecimal.ZERO;
@@ -77,8 +113,7 @@ public class CryptoService {
 			.multiply(BigDecimal.valueOf(100));
 	}
 
-	private int getScale(String symbol) {
-		String tickSize = redisCacheService.get(RedisKey.TICK_SIZE_KEY_PREFIX.getValue() + symbol);
+	private int getScale(String tickSize) {
 		BigDecimal tickSizeDecimal = new BigDecimal(tickSize).stripTrailingZeros();
 		return Math.max(0, tickSizeDecimal.scale());
 	}


### PR DESCRIPTION
#### 실시간 WebSocket 스트림이 최신 데이터를 제공하기 전, 사용자가 차트 페이지에 진입했을 때 빈 화면을 보지 않도록 과거의 캔들스틱(Kline) 데이터를 미리 채워주는 API를 구현했습니다.

#### CryptoController
- GET /chart 엔드포인트를 추가했습니다.
- @RequestParam으로 symbol과 interval을 받으며, interval은 기본값으로 15m를 사용합니다.
#### CryptoService
- BinanceClient는 비동기/논블로킹 I/O를 위해 WebClient를 사용하며, 그 결과로 Mono<List<...>>를 반환합니다.
하지만 이 메서드를 호출하는 CryptoController는 서블릿 기반의 동기/블로킹 방식으로 동작합니다.
따라서, 리액티브 스트림의 결과를 동기식 메서드의 반환 타입(List<ChartResponse>)에 맞추기 위해 .block()을 사용했습니다.