### PR TITLE
refactor: 검색 기능을 Full-Text Search로 리팩토링

### DIFF
--- a/src/main/java/com/zunza/buythedip/crypto/repository/CryptoRepository.java
+++ b/src/main/java/com/zunza/buythedip/crypto/repository/CryptoRepository.java
@@ -23,27 +23,41 @@ public interface CryptoRepository extends JpaRepository<Crypto, Long> {
 
 	@Query(
 		"""
-		SELECT new com.zunza.buythedip.crypto.dto.CryptoSuggestResponse(
-			c.id,
-			c.name,
-			c.symbol,
-			c.logo
-		)
+		SELECT c
 		FROM Crypto c
-		WHERE LOWER(c.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
-			OR LOWER(c.symbol) LIKE LOWER(CONCAT('%', :keyword, '%'))
-		ORDER BY
-			CASE WHEN LOWER(c.symbol) = LOWER(:keyword) THEN 1
-				WHEN LOWER(c.name) = LOWER(:keyword) THEN 2
-				WHEN LOWER(c.symbol) LIKE LOWER(CONCAT(:keyword, '%')) THEN 3
-				WHEN LOWER(c.name) LIKE LOWER(CONCAT(:keyword, '%')) THEN 4
-				WHEN LOWER(c.symbol) LIKE LOWER(CONCAT('%', :keyword, '%')) THEN 5
-				WHEN LOWER(c.name) LIKE LOWER(CONCAT('%', :keyword, '%')) THEN 6
-				ELSE 7
-			END,
-			LENGTH(c.name),
-			c.name
+		JOIN FETCH c.metadata
 		"""
 	)
-	List<CryptoSuggestResponse> findByKeyword(@Param("keyword") String keyword);
+	List<Crypto> findAllWithMetadata();
+
+	// @Query(
+	// 	"""
+	// 	SELECT new com.zunza.buythedip.crypto.dto.CryptoSuggestResponse(
+	// 		c.id,
+	// 		c.name,
+	// 		c.symbol,
+	// 		m.logo
+	// 	)
+	// 	FROM Crypto c
+	// 	JOIN c.metadata m
+	// 	WHERE c.name LIKE CONCAT('%', :keyword, '%')
+	// 		OR c.symbol LIKE CONCAT('%', :keyword, '%')
+	// 	ORDER BY m.marketCapRank asc
+	// 	"""
+	// )
+	@Query(
+		value = """
+        SELECT
+            c.id,
+            c.name,
+            c.symbol,
+            m.logo
+        FROM crypto as c
+        JOIN crypto_metadata as m on c.id = m.crypto_id
+        WHERE MATCH(c.name, c.symbol) AGAINST(?1 IN BOOLEAN MODE)
+        ORDER BY m.market_cap_rank asc
+        """,
+		nativeQuery = true
+	)
+	List<CryptoSuggestResponse> findByKeyword(String keyword);
 }


### PR DESCRIPTION
#### 기존 findByKeyword 메서드는 LIKE '%:keyword%'를 사용하여 검색을 구현했습니다. 하지만 prefix 와일드카드(%)를 사용하는 LIKE 쿼리는 데이터베이스의 B-Tree 인덱스를 활용하지 못합니다. 이로 인해 모든 검색 요청마다 Full Table Scan이 발생하며, 추후 암호화폐 데이터가 증가하면 따라 응답 시간 길어질 것으로 판단했습니다. 또한 정렬 조건에 시총 순위를 적용하여 사용자들의 관심도가 높을만한 암호화폐가 상단에 노출되도록 했습니다.

#### Full-Text Search 도입
- DB에 name과 symbol로 FULLTEXT INDEX를 생성한 후, crypto 테이블의 name과 symbol 컬럼을 대상으로 MATCH...AGAINST 구문을 사용하는 네이티브 쿼리로 변경했습니다. 
- 검색된 결과를 시가총액 순위(market_cap_rank) 오름차순으로 정렬하도록 ORDER BY 절을 추가했습니다.