### PR TITLE
refactor: StringRedisTemplate과 Lua 스크립트로 직접 구현했던 분산 락 로직을 Redisson으로 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,8 +35,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'io.jsonwebtoken:jjwt:0.12.6' // JWT
 	implementation 'org.springframework.boot:spring-boot-starter-aop' // AOP
-	implementation("org.springframework.boot:spring-boot-starter-actuator") // actuator
-	implementation("io.micrometer:micrometer-registry-prometheus") // micrometer
+	implementation 'org.redisson:redisson-spring-boot-starter:3.51.0' // Redisson
+	implementation 'org.springframework.boot:spring-boot-starter-actuator' // actuator
+	implementation 'io.micrometer:micrometer-registry-prometheus' // micrometer
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.boot:spring-boot-testcontainers'

--- a/src/main/java/com/zunza/buythedip/common/annotation/CacheableWithDistributedLock.java
+++ b/src/main/java/com/zunza/buythedip/common/annotation/CacheableWithDistributedLock.java
@@ -4,6 +4,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
 
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
@@ -13,11 +14,9 @@ public @interface CacheableWithDistributedLock {
 
 	String key() default "";
 
-	long maxWaitTime() default 5000;
+	long maxWaitTime() default 5;
 
-	long lockExpireTime() default 30;
+	long lockExpireTime() default 10;
 
-	long retryInterval() default 100;
-
-	boolean allowFallback() default true;
+	TimeUnit timeUnit() default TimeUnit.SECONDS;
 }

--- a/src/main/java/com/zunza/buythedip/common/annotation/aop/CacheableWithDistributedLockAspect.java
+++ b/src/main/java/com/zunza/buythedip/common/annotation/aop/CacheableWithDistributedLockAspect.java
@@ -6,10 +6,11 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.core.DefaultParameterNameDiscoverer;
-import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
@@ -17,7 +18,6 @@ import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.stereotype.Component;
 
 import com.zunza.buythedip.common.annotation.CacheableWithDistributedLock;
-import com.zunza.buythedip.infrastructure.redis.service.RedisDistributedLock;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,118 +25,69 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class CacheableWithDistributedLockAspect {
-	private final RedisDistributedLock distributedLock;
+	private static final String LOCK_KEY_PREFIX = "LOCK";
+	private final RedissonClient redissonClient;
 	private final CacheManager cacheManager;
 	private final DefaultParameterNameDiscoverer parameterNameDiscoverer = new DefaultParameterNameDiscoverer();
 	private final ExpressionParser expressionParser = new SpelExpressionParser();
 
-	@Around("@annotation(cacheableWithDistributedLock)")
-	public Object handleCacheableWithDistributedLock(
-		ProceedingJoinPoint joinPoint,
-		CacheableWithDistributedLock cacheableWithDistributedLock
-	) throws Throwable {
-
+	@Around("@annotation(com.zunza.buythedip.common.annotation.CacheableWithDistributedLock)")
+	public Object handleCacheableWithDistributedLock(ProceedingJoinPoint joinPoint) throws Throwable {
 		MethodSignature signature = (MethodSignature) joinPoint.getSignature();
 		Method method = signature.getMethod();
-		Object[] args = joinPoint.getArgs();
+		CacheableWithDistributedLock annotation = method.getAnnotation(CacheableWithDistributedLock.class);
 
-		String cacheName = determineCacheName(cacheableWithDistributedLock, method);
-		String cacheKey = calculateCacheKey(cacheableWithDistributedLock, method, args);
-
+		String cacheKey = generateCacheKey(annotation.key(), method, joinPoint.getArgs());
+		String cacheName = annotation.value()[0];
 		Cache cache = cacheManager.getCache(cacheName);
-		if (cache == null) {
-			throw new IllegalArgumentException("캐시가 존재하지 않습니다. [cache name]: " + cacheName);
-		}
 
 		Cache.ValueWrapper cachedValue = cache.get(cacheKey);
 		if (cachedValue != null) {
 			return cachedValue.get();
 		}
 
-		return executeWithDistributedLock(joinPoint, cache, cacheKey, cacheableWithDistributedLock);
-	}
+		String lockKey = LOCK_KEY_PREFIX + cacheName + "::" + cacheKey;
+		RLock lock = redissonClient.getLock(lockKey);
+		boolean isLocked = false;
 
-	private String determineCacheName(
-		CacheableWithDistributedLock annotation,
-		Method method
-	) {
-		if (annotation.value().length > 0) {
-			return annotation.value()[0];
+		try {
+			isLocked = lock.tryLock(annotation.maxWaitTime(), annotation.lockExpireTime(), annotation.timeUnit());
+			if (!isLocked) {
+				throw new RuntimeException("분산 락을 획득하지 못했습니다.");
+			}
+
+			// double check
+			cachedValue = cache.get(cacheKey);
+			if (cachedValue != null) {
+				return cachedValue.get();
+			}
+
+			Object result = joinPoint.proceed();
+
+			if (result != null) {
+				cache.put(cacheKey, result);
+			}
+			return result;
+		} finally {
+			if (isLocked && lock.isHeldByCurrentThread()) {
+				lock.unlock();
+			}
 		}
-
-		return method.getDeclaringClass().getSimpleName() + "." + method.getName();
 	}
 
-	private String calculateCacheKey(
-		CacheableWithDistributedLock annotation,
+	private String generateCacheKey(
+		String keyExpression,
 		Method method,
 		Object[] args
 	) {
-		if (!annotation.key().isEmpty()) {
-			return evaluateSpelExpression(annotation.key(), method, args);
-		}
-
-		StringBuilder keyBuilder = new StringBuilder();
-		for (int i = 0; i < args.length; i++) {
-			if (i > 0) keyBuilder.append(":");
-			keyBuilder.append(args[i] != null ? args[i].toString() : "null");
-		}
-		return keyBuilder.toString();
-	}
-
-	private String evaluateSpelExpression(
-		String expression,
-		Method method,
-		Object[] args
-	) {
-		Expression spelExpression = expressionParser.parseExpression(expression);
-		EvaluationContext context = new StandardEvaluationContext();
+		StandardEvaluationContext context = new StandardEvaluationContext();
+		Expression spelExpression = expressionParser.parseExpression(keyExpression);
 
 		String[] paramNames = parameterNameDiscoverer.getParameterNames(method);
-
 		for (int i = 0; i < args.length; i++) {
 			context.setVariable(paramNames[i], args[i]);
 		}
 
 		return spelExpression.getValue(context, String.class);
-	}
-
-	private Object executeWithDistributedLock(
-		ProceedingJoinPoint joinPoint,
-		Cache cache,
-		String cacheKey,
-		CacheableWithDistributedLock annotation
-	) throws Throwable {
-		String lockKey = "lock:" + cache.getName() + ":" + cacheKey;
-
-		RedisDistributedLock.LockInfo lockInfo = distributedLock.tryLockWithRetry(
-			lockKey,
-			annotation.lockExpireTime(),
-			annotation.maxWaitTime(),
-			annotation.retryInterval()
-		);
-
-		if (lockInfo != null) {
-			try {
-				Cache.ValueWrapper cachedValue = cache.get(cacheKey);
-				if (cachedValue != null) {
-					return cachedValue.get();
-				}
-
-				Object result = joinPoint.proceed();
-				cache.put(cacheKey, result);
-
-				return result;
-
-			} finally {
-				distributedLock.unlock(lockInfo);
-			}
-		} else {
-			if (annotation.allowFallback()) {
-				return joinPoint.proceed();
-			} else {
-				throw new RuntimeException("분산 락을 획득하지 못했습니다. [cache key]: " + cacheKey);
-			}
-		}
 	}
 }


### PR DESCRIPTION
#### 기존 @CacheableWithDistributedLock Aspect에서 사용하던, 수동으로 구현된 분산 락 로직을 Redisson으로 리팩토링했습니다. StringRedisTemplate 기반으로 구현한 분산 락은 잘 동작했지만 락 획득을 위한 재시도 루프와 안전한 락 해제를 위한 Lua 스크립트를 직접 작성해야했습니다.

#### Redisson 도입
- 복잡했던 tryLockWithRetry와 unlock 로직이 redissonClient.getLock(lockKey)으로 RLock 객체를 얻어와 lock.tryLock()과 lock.unlock()을 호출하는 간소화된 코드로 변경되었습니다.
- tryLock으로 락을 획득하면, Watchdog이라는 백그라운드 타이머가 활성화됩니다. Watchdog은 락 만료 시간의 1/3이 지날 때마다 해당 락을 점유한 스레드가 아직 살아있는지 확인하고, 살아있다면 락의 TTL을 자동으로 연장해 줍니다.