### PR TITLE
feat: 분산 락을 이용한 캐시 웜업 중복 실행 방지

### DIFF
--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/service/RedisCacheService.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/service/RedisCacheService.java
@@ -21,4 +21,8 @@ public class RedisCacheService {
 	public boolean delete(String key) {
 		return redisTemplate.delete(key);
 	}
+
+	public boolean hasKey(String key) {
+		return redisTemplate.hasKey(key);
+	}
 }

--- a/src/main/java/com/zunza/buythedip/warmup/CacheWarmUpRunner.java
+++ b/src/main/java/com/zunza/buythedip/warmup/CacheWarmUpRunner.java
@@ -1,5 +1,9 @@
 package com.zunza.buythedip.warmup;
 
+import java.util.concurrent.TimeUnit;
+
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
@@ -11,33 +15,56 @@ import com.zunza.buythedip.infrastructure.redis.service.RedisCacheService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-/**
- * TODO: 로컬 캐시 적용하기
- */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class CacheWarmUpRunner implements ApplicationRunner {
 	private static final String SYMBOL_SUFFIX = "USDT";
+	private static final String DONE_KEY = "TICK:SIZE:WARMUP:DONE::";
+	private static final String LOCK_KEY = "LOCK:TICK:SIZE:WARMUP";
 
+	private final RedissonClient redissonClient;
 	private final CryptoRepository cryptoRepository;
 	private final RedisCacheService redisCacheService;
 
 	@Override
 	public void run(ApplicationArguments args) {
-		long startTime = System.currentTimeMillis();
-		log.info("tick size 캐싱 작업 시작");
+		if (redisCacheService.hasKey(DONE_KEY)) {
+			log.info("이미 웜업이 완료됐습니다.");
+			return;
+		}
 
-		cryptoRepository.findAllWithMetadata()
-			.forEach(crypto ->
-				redisCacheService.set(
-					RedisKey.TICK_SIZE_KEY_PREFIX.getValue() + crypto.getSymbol() + SYMBOL_SUFFIX,
-					crypto.getMetadata().getTickSize().toString()
-				)
-			);
+		RLock lock = redissonClient.getLock(LOCK_KEY);
+		boolean isLocked = false;
 
-		long endTime = System.currentTimeMillis();
-		log.info("tick size 캐싱 작업이 완료되었습니다. (총 소요 시간: {}ms)]",
-			endTime - startTime);
+		try {
+			isLocked = lock.tryLock(15, 30, TimeUnit.SECONDS);
+			if (!isLocked) {
+				log.info("분산 락을 획득하지 못했습니다.");
+				return;
+			}
+
+			long startTime = System.currentTimeMillis();
+			log.info("tick size 캐싱 작업 시작");
+
+			cryptoRepository.findAllWithMetadata()
+				.forEach(crypto ->
+					redisCacheService.set(
+						RedisKey.TICK_SIZE_KEY_PREFIX.getValue() + crypto.getSymbol() + SYMBOL_SUFFIX,
+						crypto.getMetadata().getTickSize().toString()
+					)
+				);
+
+			redisCacheService.set(DONE_KEY, "1");
+			long endTime = System.currentTimeMillis();
+			log.info("tick size 캐싱 작업이 완료되었습니다. (총 소요 시간: {}ms)]", endTime - startTime);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			log.warn("warmup interrupted", e);
+		} finally {
+			if (isLocked && lock.isHeldByCurrentThread()) {
+				lock.unlock();
+			}
+		}
 	}
 }


### PR DESCRIPTION
#### 다중 서버 환경에서 애플리케이션이 동시에 시작되거나 추후에 스케일 아웃 시 캐시 웜업 로직이 중복으로 실행되는 것을 방지합니다.

#### Redisson 분산 락 도입:
- CacheWarmUpRunner에 RedissonClient를 주입받아 분산 락(RLock)을 사용하도록 구현했습니다.
#### 웜업 완료 마커 추가
- TICK:SIZE:WARMUP:DONE:: 라는 Redis 키를 '마커'로 활용합니다.
- 웜업이 성공적으로 완료되면 이 키를 생성하고, 이후에 시작되는 서버 인스턴스들은 이 키의 존재 여부를 먼저 확인하여 불필요한 락 획득 시도 및 웜업 로직을 건너뛰도록 했습니다.