### PR TITLE
feat: ShedLock을 적용하여 스케줄러의 분산 환경 실행 보장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
 	implementation 'org.redisson:redisson-spring-boot-starter:3.51.0' // Redisson
 	implementation 'org.springframework.boot:spring-boot-starter-actuator' // actuator
 	implementation 'io.micrometer:micrometer-registry-prometheus' // micrometer
+	implementation 'net.javacrumbs.shedlock:shedlock-spring:6.9.0' // ShedLock
+	implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:6.9.0'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.boot:spring-boot-testcontainers'

--- a/src/main/java/com/zunza/buythedip/config/ShedLockConfig.java
+++ b/src/main/java/com/zunza/buythedip/config/ShedLockConfig.java
@@ -1,0 +1,26 @@
+package com.zunza.buythedip.config;
+
+import javax.sql.DataSource;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+
+@Configuration
+@EnableSchedulerLock(defaultLockAtMostFor = "1m")
+public class ShedLockConfig {
+
+	@Bean
+	public LockProvider lockProvider(DataSource dataSource) {
+		return new JdbcTemplateLockProvider(
+			JdbcTemplateLockProvider.Configuration.builder()
+				.withJdbcTemplate(new JdbcTemplate(dataSource))
+				.usingDbTime()
+				.build()
+		);
+	}
+}

--- a/src/main/java/com/zunza/buythedip/crypto/scheduler/CryptoScheduler.java
+++ b/src/main/java/com/zunza/buythedip/crypto/scheduler/CryptoScheduler.java
@@ -6,6 +6,8 @@ import java.util.List;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+
 import com.zunza.buythedip.crypto.repository.CryptoRepository;
 import com.zunza.buythedip.external.binance.client.BinanceClient;
 import com.zunza.buythedip.infrastructure.redis.constant.RedisKey;
@@ -28,6 +30,7 @@ public class CryptoScheduler {
 	private static final String SYMBOL_SUFFIX = "USDT";
 
 	@Scheduled(cron = "3 0 0 * * *", zone = "UTC")
+	@SchedulerLock(name = "cacheDailyOpenPrice_lock")
 	public void cacheDailyOpenPrice() {
 		long startTime = System.currentTimeMillis();
 		log.info("open price 캐싱 작업을 시작합니다.");


### PR DESCRIPTION
#### 여러 인스턴스에서 동일한 스케줄 작업이 중복 실행되는 문제를 방지하기 위해 ShedLock을 도입했습니다.

#### ShedLockConfig
- JdbcTemplateLockProvider를 사용하여, 데이터베이스를 락 저장소로 활용합니다. 
- defaultLockAtMostFor = "1m" 락을 획득한 인스턴스가 비정상적으로 종료되어 락을 해제하지 못할 경우를 대비한 설정입니다.
#### @SchedulerLock 적용
- cacheDailyOpenPrice 메서드에 @SchedulerLock(name = "cacheDailyOpenPrice_lock") 어노테이션을 추가했습니다.
