### PR TITLE
refactor: 검색 결과 정렬 로직에 관련도순을 추가하여 개선

### DIFF
--- a/src/main/java/com/zunza/buythedip/crypto/repository/CryptoRepository.java
+++ b/src/main/java/com/zunza/buythedip/crypto/repository/CryptoRepository.java
@@ -55,7 +55,12 @@ public interface CryptoRepository extends JpaRepository<Crypto, Long> {
         FROM crypto as c
         JOIN crypto_metadata as m on c.id = m.crypto_id
         WHERE MATCH(c.name, c.symbol) AGAINST(?1 IN BOOLEAN MODE)
-        ORDER BY m.market_cap_rank asc
+        ORDER BY
+        CASE WHEN c.symbol = ?1 OR c.name = ?1 THEN 1
+        WHEN c.symbol LIKE ?1% OR c.name LIKE ?1% THEN 2
+        ELSE 3
+        END,
+        m.market_cap_rank asc
         """,
 		nativeQuery = true
 	)


### PR DESCRIPTION
#### 사용자가 'he'를 입력해도 시총이 더 높은 다른 코인(ex. ethereum)이 먼저 노출되는 등 직관적이지 않은 결과를 반환하는 경우가 있었습니다. 때문에 기존의 시가총액 순위 단일 기준으로 정렬되던 검색 기능의 정확도를 높이기 위해, CASE 문을 활용한 관련도 기반의 정렬 로직으로 리팩토링했습니다.

- 1순위 정확히 일치: 사용자가 입력한 키워드와 심볼/이름이 완벽히 일치하는 결과를 최상단에 노출합니다.
- 2순위 접두사 일치: 사용자가 입력한 키워드로 심볼/이름이 시작하는 결과를 차순위로 노출합니다.
- 3순위 그 외: 나머지 Full-Text Search 결과를 노출합니다.
- 보조 정렬: 위 각 우선순위 그룹 내에서는 기존과 같이 시가총액 순위로 정렬합니다.