### PR TITLE
feat: 리더 선출 패턴을 적용한 분산 스트림 관리자 구현

### DIFF
--- a/src/main/java/com/zunza/buythedip/external/binance/stream/handler/KlineStreamHandler.java
+++ b/src/main/java/com/zunza/buythedip/external/binance/stream/handler/KlineStreamHandler.java
@@ -17,31 +17,21 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequiredArgsConstructor
 public class KlineStreamHandler extends TextWebSocketHandler {
-	private final String interval;
-	private final List<String> symbols;
-	private final int chunkSize;
+	private final List<String> params;
 	private final ObjectMapper objectMapper;
 	private final CryptoService cryptoService;
 
 	@Override
 	public void afterConnectionEstablished(WebSocketSession session) throws Exception {
-		for (int i = 0; i < symbols.size(); i += chunkSize) {
-			List<String> chunk = symbols.subList(i, Math.min(i + chunkSize, symbols.size()));
+		SubscribeRequest request = new SubscribeRequest(
+			"SUBSCRIBE",
+			params,
+			session.getId()
+		);
 
-			List<String> subscribeParams = chunk.stream()
-				.map(symbol -> symbol + interval)
-				.toList();
-
-			SubscribeRequest request = new SubscribeRequest(
-				"SUBSCRIBE",
-				subscribeParams,
-				String.valueOf(i / chunkSize + 1)
-			);
-
-			String payload = objectMapper.writeValueAsString(request);
-			session.sendMessage(new TextMessage(payload));
-			Thread.sleep(200);
-		}
+		String payload = objectMapper.writeValueAsString(request);
+		session.sendMessage(new TextMessage(payload));
+		Thread.sleep(200);
 	}
 
 	@Override

--- a/src/main/java/com/zunza/buythedip/external/binance/stream/handler/TickerStreamHandler.java
+++ b/src/main/java/com/zunza/buythedip/external/binance/stream/handler/TickerStreamHandler.java
@@ -17,26 +17,21 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequiredArgsConstructor
 public class TickerStreamHandler extends TextWebSocketHandler {
-	private final List<String> symbols;
-	private final int chunkSize;
+	private final List<String> params;
 	private final ObjectMapper objectMapper;
 	private final CryptoService cryptoService;
 
 	@Override
 	public void afterConnectionEstablished(WebSocketSession session) throws Exception {
-		for (int i = 0; i < symbols.size(); i += chunkSize) {
-			List<String> chunk = symbols.subList(i, Math.min(i + chunkSize, symbols.size()));
+		SubscribeRequest payloadObj = new SubscribeRequest(
+			"SUBSCRIBE",
+			params,
+			session.getId()
+		);
 
-			SubscribeRequest payloadObj = new SubscribeRequest(
-				"SUBSCRIBE",
-				chunk,
-				String.valueOf((i / chunkSize) + 1)
-			);
-
-			String payload = objectMapper.writeValueAsString(payloadObj);
-			session.sendMessage(new TextMessage(payload));
-			Thread.sleep(200);
-		}
+		String payload = objectMapper.writeValueAsString(payloadObj);
+		session.sendMessage(new TextMessage(payload));
+		Thread.sleep(200);
 	}
 
 	@Override

--- a/src/main/java/com/zunza/buythedip/external/binance/stream/manager/BinanceStreamManager.java
+++ b/src/main/java/com/zunza/buythedip/external/binance/stream/manager/BinanceStreamManager.java
@@ -1,0 +1,182 @@
+package com.zunza.buythedip.external.binance.stream.manager;
+
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.client.WebSocketClient;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zunza.buythedip.crypto.repository.CryptoRepository;
+import com.zunza.buythedip.crypto.service.CryptoService;
+import com.zunza.buythedip.external.binance.stream.handler.KlineStreamHandler;
+import com.zunza.buythedip.external.binance.stream.handler.TickerStreamHandler;
+
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BinanceStreamManager {
+	private final RedissonClient redissonClient;
+	private final ObjectMapper objectMapper;
+	private final WebSocketClient webSocketClient;
+	private final CryptoService cryptoService;
+	private final CryptoRepository cryptoRepository;
+
+	private static final String LEADER_LOCK_KEY = "BINANCE:STREAM:LEADER:LOCK";
+	private static final String STREAM_URL = "wss://data-stream.binance.vision/stream";
+	private static final String TICKER_STREAM_SUFFIX = "usdt@miniTicker";
+	private static final String KLINE_STREAM_SUFFIX = "usdt@kline_";
+	private static final int CHUNK_SIZE = 203;
+
+	private RLock lock;
+	private volatile boolean isLeader = false;
+	private volatile long lastConnectionTime = 0L;
+	private final List<WebSocketSession> activeSessions = new CopyOnWriteArrayList<>();
+	private final String hostname = System.getenv("HOSTNAME");
+
+	@EventListener(ApplicationReadyEvent.class)
+	public void onApplicationReadyEvent(ApplicationReadyEvent event) {
+		Thread thread = new Thread(this::tryToBecomeLeader);
+		thread.setDaemon(true);
+		thread.start();
+	}
+
+	@PreDestroy
+	public void destroy() {
+		if (lock != null && lock.isHeldByCurrentThread()) {
+			lock.unlock();
+			log.info("애플리케이션 종료... 락을 해제했습니다.");
+		}
+	}
+
+	public void tryToBecomeLeader() {
+		lock = redissonClient.getLock(LEADER_LOCK_KEY);
+
+		try {
+			while (!Thread.currentThread().isInterrupted()) {
+				try {
+					lock.lock();
+					isLeader = true;
+					log.info("[{}] 리더로 지정... 스트림 연결을 시작합니다.", hostname);
+					stopStreams();
+					startStreams();
+
+					while (lock.isLocked() && lock.isHeldByCurrentThread()) {
+						Thread.sleep(5000);
+					}
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					break;
+				} finally {
+					if (lock.isHeldByCurrentThread()) {
+						log.warn("락을 해제합니다.");
+						lock.unlock();
+					}
+					isLeader = false;
+					log.warn("[{}] 리더 해제... 스트림 연결을 종료합니다.", hostname);
+					stopStreams();
+				}
+			}
+		} catch (Exception e) {
+			log.error("예기치 않은 오류 발생", e);
+		}
+	}
+
+	@Scheduled(fixedDelay = 1, timeUnit = TimeUnit.MINUTES)
+	public void scheduledReconnect() {
+		if (!isLeader) {
+			return;
+		}
+
+		if (lastConnectionTime == 0L) {
+			return;
+		}
+
+		long uptime = System.currentTimeMillis() - lastConnectionTime;
+		long tenHoursInMillis = 10 * 60 * 60 * 1000L;
+
+		if (uptime > tenHoursInMillis) {
+			log.info("연결 유지 시간이 10시간을 초과했습니다 ({}분 경과). 재연결을 시작합니다.", TimeUnit.MILLISECONDS.toMinutes(uptime));
+
+			stopStreams();
+			startStreams();
+		}
+	}
+
+	private void startStreams() {
+		List<String> symbols = cryptoRepository.findAll().stream()
+			.map(crypto -> crypto.getSymbol().toLowerCase())
+			.toList();
+
+		if (symbols.isEmpty()) {
+			log.warn("스트림을 시작할 심볼이 없습니다.");
+			return;
+		}
+
+		startTickerStream(symbols);
+		startKlineStream(symbols);
+		this.lastConnectionTime = System.currentTimeMillis();
+		log.info("스트림 연결이 완료되었습니다. 마지막 연결 시간: {}", new Date(this.lastConnectionTime));
+	}
+
+	private void stopStreams() {
+		log.info("모든 활성 웹소켓 세션({})을 종료합니다.", activeSessions.size());
+		activeSessions.forEach(session -> {
+			try {
+				if (session.isOpen()) {
+					session.close();
+				}
+			} catch (Exception e) {
+				log.warn("웹소켓 세션 종료 중 오류 발생: {}", session.getId(), e);
+			}
+		});
+		activeSessions.clear();
+		log.info("스트림 연결 해제가 완료되었습니다. 마지막 연결 해제 시간: {}", new Date(System.currentTimeMillis()));
+	}
+
+	private void startTickerStream(List<String> symbols) {
+		List<String> params = symbols.stream()
+			.map(symbol -> symbol + TICKER_STREAM_SUFFIX)
+			.toList();
+
+		for (int i = 0; i < params.size(); i += CHUNK_SIZE) {
+			List<String> chunk = params.subList(i, Math.min(i + CHUNK_SIZE, params.size()));
+			TickerStreamHandler handler = new TickerStreamHandler(chunk, objectMapper, cryptoService);
+			webSocketClient.execute(handler, STREAM_URL)
+				.thenAccept(activeSessions::add);
+
+			log.info("Ticker 스트림 연결 시작... {}개의 심볼", chunk.size());
+		}
+	}
+
+	private void startKlineStream(List<String> symbols) {
+		List<String> klineIntervals = List.of("1m", "3m", "5m", "15m", "30m", "1h", "4h", "1d", "1w", "1M");
+
+		klineIntervals.forEach(interval -> {
+			List<String> params = symbols.stream()
+				.map(symbol -> symbol + KLINE_STREAM_SUFFIX + interval)
+				.toList();
+
+			for (int i = 0; i < params.size(); i += CHUNK_SIZE) {
+				List<String> chunk = params.subList(i, Math.min(i + CHUNK_SIZE, params.size()));
+				KlineStreamHandler handler = new KlineStreamHandler(chunk, objectMapper, cryptoService);
+				webSocketClient.execute(handler, STREAM_URL)
+					.thenAccept(activeSessions::add);
+
+				log.info("Kline 스트림 연결 시작... {}개의 심볼 {} 인터벌", chunk.size(), interval);
+			}
+		});
+	}
+}

--- a/src/main/java/com/zunza/buythedip/external/binance/stream/manager/KlineStreamManager.java
+++ b/src/main/java/com/zunza/buythedip/external/binance/stream/manager/KlineStreamManager.java
@@ -1,55 +1,55 @@
-package com.zunza.buythedip.external.binance.stream.manager;
-
-import java.util.List;
-
-import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.context.event.EventListener;
-import org.springframework.stereotype.Component;
-import org.springframework.web.socket.client.WebSocketClient;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.zunza.buythedip.crypto.repository.CryptoRepository;
-import com.zunza.buythedip.crypto.service.CryptoService;
-import com.zunza.buythedip.external.binance.stream.handler.KlineStreamHandler;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
-@Slf4j
-@Component
-@RequiredArgsConstructor
-public class KlineStreamManager {
-	private final ObjectMapper objectMapper;
-	private final WebSocketClient webSocketClient;
-	private final CryptoService cryptoService;
-	private final CryptoRepository cryptoRepository;
-
-	private static final String KLINE_STREAM_URL = "wss://data-stream.binance.vision/stream";
-	private static final String STREAM_SUFFIX = "usdt@kline_";
-	private static final List<String> KLINE_INTERVALS = List.of("1m", "3m", "5m", "15m", "30m", "1h", "4h", "1d", "1w", "1M");
-	private static final int CHUNK_SIZE = 203;
-
-	@EventListener(ApplicationReadyEvent.class)
-	public void startStreaming() {
-		List<String> symbols = cryptoRepository.findAll().stream()
-			.map(crypto -> crypto.getSymbol().toLowerCase() + STREAM_SUFFIX)
-			.toList();
-
-		if (symbols.isEmpty()) {
-			log.warn("심볼이 존재하지 않습니다.");
-			return;
-		}
-
-		KLINE_INTERVALS.forEach(interval -> {
-			KlineStreamHandler handler = new KlineStreamHandler(
-				interval,
-				symbols,
-				CHUNK_SIZE,
-				objectMapper,
-				cryptoService
-			);
-
-			webSocketClient.execute(handler, KLINE_STREAM_URL);
-		});
-	}
-}
+// package com.zunza.buythedip.external.binance.stream.manager;
+//
+// import java.util.List;
+//
+// import org.springframework.boot.context.event.ApplicationReadyEvent;
+// import org.springframework.context.event.EventListener;
+// import org.springframework.stereotype.Component;
+// import org.springframework.web.socket.client.WebSocketClient;
+//
+// import com.fasterxml.jackson.databind.ObjectMapper;
+// import com.zunza.buythedip.crypto.repository.CryptoRepository;
+// import com.zunza.buythedip.crypto.service.CryptoService;
+// import com.zunza.buythedip.external.binance.stream.handler.KlineStreamHandler;
+//
+// import lombok.RequiredArgsConstructor;
+// import lombok.extern.slf4j.Slf4j;
+//
+// @Slf4j
+// @Component
+// @RequiredArgsConstructor
+// public class KlineStreamManager {
+// 	private final ObjectMapper objectMapper;
+// 	private final WebSocketClient webSocketClient;
+// 	private final CryptoService cryptoService;
+// 	private final CryptoRepository cryptoRepository;
+//
+// 	private static final String KLINE_STREAM_URL = "wss://data-stream.binance.vision/stream";
+// 	private static final String STREAM_SUFFIX = "usdt@kline_";
+// 	private static final List<String> KLINE_INTERVALS = List.of("1m", "3m", "5m", "15m", "30m", "1h", "4h", "1d", "1w", "1M");
+// 	private static final int CHUNK_SIZE = 203;
+//
+// 	// @EventListener(ApplicationReadyEvent.class)
+// 	public void startStreaming() {
+// 		List<String> symbols = cryptoRepository.findAll().stream()
+// 			.map(crypto -> crypto.getSymbol().toLowerCase() + STREAM_SUFFIX)
+// 			.toList();
+//
+// 		if (symbols.isEmpty()) {
+// 			log.warn("심볼이 존재하지 않습니다.");
+// 			return;
+// 		}
+//
+// 		KLINE_INTERVALS.forEach(interval -> {
+// 			KlineStreamHandler handler = new KlineStreamHandler(
+// 				interval,
+// 				symbols,
+// 				CHUNK_SIZE,
+// 				objectMapper,
+// 				cryptoService
+// 			);
+//
+// 			webSocketClient.execute(handler, KLINE_STREAM_URL);
+// 		});
+// 	}
+// }

--- a/src/main/java/com/zunza/buythedip/external/binance/stream/manager/TickerStreamManager.java
+++ b/src/main/java/com/zunza/buythedip/external/binance/stream/manager/TickerStreamManager.java
@@ -1,51 +1,51 @@
-package com.zunza.buythedip.external.binance.stream.manager;
-
-import java.util.List;
-
-import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.context.event.EventListener;
-import org.springframework.stereotype.Component;
-import org.springframework.web.socket.client.WebSocketClient;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.zunza.buythedip.crypto.repository.CryptoRepository;
-import com.zunza.buythedip.crypto.service.CryptoService;
-import com.zunza.buythedip.external.binance.stream.handler.TickerStreamHandler;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
-@Slf4j
-@Component
-@RequiredArgsConstructor
-public class TickerStreamManager {
-	private final ObjectMapper objectMapper;
-	private final WebSocketClient webSocketClient;
-	private final CryptoService cryptoService;
-	private final CryptoRepository cryptoRepository;
-
-	private static final String TICKER_STREAM_URL = "wss://data-stream.binance.vision/stream";
-	private static final String TICKER_STREAM_SUFFIX = "usdt@miniTicker";
-	private static final int CHUNK_SIZE = 203;
-
-	@EventListener(ApplicationReadyEvent.class)
-	public void startStreaming() {
-		List<String> symbols = cryptoRepository.findAll().stream()
-			.map(crypto -> crypto.getSymbol().toLowerCase() + TICKER_STREAM_SUFFIX)
-			.toList();
-
-		if (symbols.isEmpty()) {
-			log.warn("심볼이 존재하지 않습니다.");
-			return;
-		}
-
-		TickerStreamHandler handler = new TickerStreamHandler(
-			symbols,
-			CHUNK_SIZE,
-			objectMapper,
-			cryptoService
-		);
-
-		webSocketClient.execute(handler, TICKER_STREAM_URL);
-	}
-}
+// package com.zunza.buythedip.external.binance.stream.manager;
+//
+// import java.util.List;
+//
+// import org.springframework.boot.context.event.ApplicationReadyEvent;
+// import org.springframework.context.event.EventListener;
+// import org.springframework.stereotype.Component;
+// import org.springframework.web.socket.client.WebSocketClient;
+//
+// import com.fasterxml.jackson.databind.ObjectMapper;
+// import com.zunza.buythedip.crypto.repository.CryptoRepository;
+// import com.zunza.buythedip.crypto.service.CryptoService;
+// import com.zunza.buythedip.external.binance.stream.handler.TickerStreamHandler;
+//
+// import lombok.RequiredArgsConstructor;
+// import lombok.extern.slf4j.Slf4j;
+//
+// @Slf4j
+// @Component
+// @RequiredArgsConstructor
+// public class TickerStreamManager {
+// 	private final ObjectMapper objectMapper;
+// 	private final WebSocketClient webSocketClient;
+// 	private final CryptoService cryptoService;
+// 	private final CryptoRepository cryptoRepository;
+//
+// 	private static final String TICKER_STREAM_URL = "wss://data-stream.binance.vision/stream";
+// 	private static final String TICKER_STREAM_SUFFIX = "usdt@miniTicker";
+// 	private static final int CHUNK_SIZE = 203;
+//
+// 	// @EventListener(ApplicationReadyEvent.class)
+// 	public void startStreaming() {
+// 		List<String> symbols = cryptoRepository.findAll().stream()
+// 			.map(crypto -> crypto.getSymbol().toLowerCase() + TICKER_STREAM_SUFFIX)
+// 			.toList();
+//
+// 		if (symbols.isEmpty()) {
+// 			log.warn("심볼이 존재하지 않습니다.");
+// 			return;
+// 		}
+//
+// 		TickerStreamHandler handler = new TickerStreamHandler(
+// 			symbols,
+// 			CHUNK_SIZE,
+// 			objectMapper,
+// 			cryptoService
+// 		);
+//
+// 		webSocketClient.execute(handler, TICKER_STREAM_URL);
+// 	}
+// }


### PR DESCRIPTION
#### 분산 환경에서 WebSocket 스트림 연결이 중복으로 생성되는 문제를 해결하기 위해 Redisson 분산 락을 활용한 리더 선출 패턴을 구현했습니다.

#### BinanceStreamManager
- 기존의 TickerStreamManager와 KlineStreamManager를 하나의 클래스로 통합했습니다.
- tryToBecomeLeader(): 별도의 데몬 스레드에서 실행되는 핵심 루프입니다.
- lock.lock(): 락을 획득할 때까지 대기하는 블로킹 호출입니다.
- 락 획득 성공 시, isLeader 플래그를 true로 설정하고 startStreams()를 호출합니다.
- finally 블록에서 락 해제 및 stopStreams()를 보장하여, 리더 자격을 잃었을 때 리소스를 정리합니다.

#### 주기적 재연결
- 바이낸스 웹소켓은 연결 후 11시간이 지나면 자동으로 연결을 끊습니다. 따라서 연결 후 10시간이 지나면 선제적으로  모든 스트림을 재연결하는 스케줄러를 추가했습니다