### PR TITLE
feat: Redis를 이용한 Stateless OAuth2 인증 요청 저장소 구현

### DIFF
--- a/src/main/java/com/zunza/buythedip/auth/oauth2/repository/RedisOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/zunza/buythedip/auth/oauth2/repository/RedisOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,68 @@
+package com.zunza.buythedip.auth.oauth2.repository;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zunza.buythedip.infrastructure.redis.service.RedisCacheService;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class RedisOAuth2AuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+	private final static String AUTH_REQUEST_PREFIX = "OAUTH2_AUTH_REQUEST:";
+	private final RedisCacheService cacheService;
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+		try {
+			String key = getKey(request.getParameter("state"));
+			String value = cacheService.get(key);
+			return objectMapper.readValue(value, OAuth2AuthorizationRequest.class);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public void saveAuthorizationRequest(
+		OAuth2AuthorizationRequest authorizationRequest,
+		HttpServletRequest request,
+		HttpServletResponse response
+	) {
+		try {
+			String key = getKey(authorizationRequest.getState());
+			String authRequest = objectMapper.writeValueAsString(authorizationRequest);
+			cacheService.set(key, authRequest, 5L, TimeUnit.MINUTES);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Override
+	public OAuth2AuthorizationRequest removeAuthorizationRequest(
+		HttpServletRequest request,
+		HttpServletResponse response
+	) {
+		try {
+			String key = getKey(request.getParameter("state"));
+			String value = cacheService.get(key);
+			cacheService.delete(key);
+			return objectMapper.readValue(value, OAuth2AuthorizationRequest.class);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private String getKey(String state) {
+		return AUTH_REQUEST_PREFIX + state;
+	}
+}

--- a/src/main/java/com/zunza/buythedip/config/SecurityConfig.java
+++ b/src/main/java/com/zunza/buythedip/config/SecurityConfig.java
@@ -20,6 +20,7 @@ import com.zunza.buythedip.auth.jwt.JwtExceptionFilter;
 import com.zunza.buythedip.auth.oauth2.CustomOAuth2FailureHandler;
 import com.zunza.buythedip.auth.oauth2.CustomOAuth2SuccessHandler;
 import com.zunza.buythedip.auth.oauth2.CustomOAuth2UserService;
+import com.zunza.buythedip.auth.oauth2.repository.RedisOAuth2AuthorizationRequestRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -28,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+	private final RedisOAuth2AuthorizationRequestRepository redisOAuth2AuthorizationRequestRepository;
 	private final AuthenticationConfiguration authenticationConfiguration;
 	private final CustomOAuth2UserService customOAuth2UserService;
 	private final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
@@ -71,6 +73,9 @@ public class SecurityConfig {
 			.oauth2Login(oauth2 -> oauth2
 				.userInfoEndpoint(userInfo ->
 					userInfo.userService(customOAuth2UserService)
+				)
+				.authorizationEndpoint(auth -> auth
+					.authorizationRequestRepository(redisOAuth2AuthorizationRequestRepository)
 				)
 				.successHandler(customOAuth2SuccessHandler)
 				.failureHandler(customOAuth2FailureHandler)

--- a/src/main/java/com/zunza/buythedip/infrastructure/redis/service/RedisCacheService.java
+++ b/src/main/java/com/zunza/buythedip/infrastructure/redis/service/RedisCacheService.java
@@ -1,5 +1,7 @@
 package com.zunza.buythedip.infrastructure.redis.service;
 
+import java.util.concurrent.TimeUnit;
+
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -12,6 +14,10 @@ public class RedisCacheService {
 
 	public void set(String key, String value) {
 		redisTemplate.opsForValue().set(key, value);
+	}
+
+	public void set(String key, String value, long timeout, TimeUnit unit) {
+		redisTemplate.opsForValue().set(key, value, timeout, unit);
 	}
 
 	public String get(String key) {


### PR DESCRIPTION
#### 분산 환경을 지원하기 위해, OAuth2 인증 과정의 상태 정보를 HttpSession에서 분리하여 Redis에서 관리하도록 개선합니다.

#### 문제점
- [요청 1]: 사용자 A의 로그인 요청이 서버 1로 전달됩니다. AuthorizationRequest 정보가 서버 1의 HttpSession에 저장됩니다.
- 사용자는 Google 등에서 인증을 완료하고 우리 서비스로 리다이렉트됩니다.
- [요청 2]: 로드 밸런서는 이 콜백 요청을 서버 2로 전달합니다.
- [실패]: 서버 2는 자신의 HttpSession에 AuthorizationRequest 정보가 없으므로 인증을 완료하지 못하고 오류를 발생시킵니다.

#### RedisOAuth2AuthorizationRequestRepository
- saveAuthorizationRequest: OAuth2 Provider로 리다이렉트하기 직전에 호출됩니다. OAuth2AuthorizationRequest 객체를 JSON으로 직렬화하여, state 값을 포함한 key로 Redis에 5분간 저장합니다.
- loadAuthorizationRequest: 인증 후 콜백으로 돌아왔을 때 호출됩니다. 요청 파라미터로 전달된 state 값을 사용하여 Redis에서 조회하고 역직렬화하여 반환합니다.
- removeAuthorizationRequest: 인증 흐름이 완료되면 데이터를 Redis에서 삭제합니다.
